### PR TITLE
fix: replace \donttest with @examplesIf for Census API key guard

### DIFF
--- a/R/dep_get_index.R
+++ b/R/dep_get_index.R
@@ -151,8 +151,7 @@
 #'     jurisdiction and year will receive its own row. Each unique combination of
 #'     jurisdiction, year, and deprivation measure will receive its own row.
 #'
-#' @examples
-#' \donttest{
+#' @examplesIf nzchar(Sys.getenv("CENSUS_API_KEY"))
 #'   # calculate ADI for all US counties
 #'   dep_get_index(geography = "county", index = "adi", year = 2022)
 #'
@@ -164,7 +163,6 @@
 #'   # percentiles are returned to ease comparison
 #'   dep_get_index(geography = "county", index = c("adi", "svi14"),
 #'     year = c(2018:2020), return_percentiles = TRUE)
-#' }
 #'
 #' @export
 dep_get_index <- function(geography, index, year, survey = "acs5",

--- a/man/dep_get_index.Rd
+++ b/man/dep_get_index.Rd
@@ -176,7 +176,7 @@ Downloads raw data and then calculates various measures of
     measures of deprivation or inequality.
 }
 \examples{
-\donttest{
+\dontshow{if (nzchar(Sys.getenv("CENSUS_API_KEY"))) withAutoprint(\{ # examplesIf}
   # calculate ADI for all US counties
   dep_get_index(geography = "county", index = "adi", year = 2022)
 
@@ -188,6 +188,5 @@ Downloads raw data and then calculates various measures of
   # percentiles are returned to ease comparison
   dep_get_index(geography = "county", index = c("adi", "svi14"),
     year = c(2018:2020), return_percentiles = TRUE)
-}
-
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
## Summary

Resolves CRAN ERROR on additional checks (Prof. Ripley's `donttest` runner) where examples fail on machines without `CENSUS_API_KEY`.

Closes #14

## Changes

- **`R/dep_get_index.R`** — replaced `@examples` + `\donttest{}` with `@examplesIf nzchar(Sys.getenv("CENSUS_API_KEY"))`
- **`man/dep_get_index.Rd`** — regenerated via `roxygen2::roxygenise()`

## Approach

Uses `@examplesIf` (roxygen2 ≥7.1.2), the modern CRAN-friendly pattern. Examples gracefully skip when no API key is present but still run when one is available.

## Testing

- `roxygen2::roxygenise()` ran cleanly
- Generated Rd contains the expected `\dontshow{if (...)}` guard

## UAT Required

⚠️ This PR modifies `R/dep_get_index.R` — human review of the R/ change is required before merge.