### PR TITLE
chore: update DESCRIPTION to roxygen2 8.0.0 config format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ License: Apache License (>= 2)
 URL: https://pfizer-opensource.github.io/deprivateR/, https://github.com/pfizer-opensource/deprivateR
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
 Imports:
     classInt,
     dplyr,
@@ -40,3 +39,4 @@ Suggests:
     measurements,
     testthat,
     tigris
+Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
## Summary

Updates DESCRIPTION metadata to reflect roxygen2 8.0.0 (used to regenerate docs in #25).

## Changes

- Removes deprecated `RoxygenNote: 7.3.2` field
- Adds `Config/roxygen2/version: 8.0.0` (new standard format)

## Testing

Metadata-only change — no functional impact.