### PR TITLE
test: expand unit test coverage across core functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Unit tests for `dep_get_index`, `dep_map_breaks`, `dep_quantiles`, `dep_percentiles`, and internal helpers — 179 assertions across 8 test files (#3)
 - `LICENSE.md` with full Apache 2.0 text for pkgdown site rendering (#9)
 - `CHANGELOG.md` excluded from R package tarball via `.Rbuildignore` (#21)
 - Spelling check in CI workflow with `inst/WORDLIST` for domain terms (#27)

--- a/tests/testthat/test_dep_get_index.R
+++ b/tests/testthat/test_dep_get_index.R
@@ -1,0 +1,162 @@
+context("test dep_get_index function")
+
+# test errors ------------------------------------------------
+
+test_that("missing geography triggers error", {
+  expect_error(
+    dep_get_index(index = "ndi_m", year = 2020, survey = "acs5"),
+    "A level of geography must be provided"
+  )
+})
+
+test_that("invalid geography triggers error", {
+
+  expect_error(
+    dep_get_index(geography = "hamlet", index = "ndi_m", year = 2020, survey = "acs5"),
+    "Invalid level of geography provided"
+  )
+})
+
+test_that("missing index triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", year = 2020, survey = "acs5"),
+    "A 'index' value must be provided"
+  )
+})
+
+test_that("invalid index triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ham", year = 2020, survey = "acs5"),
+    "Invalid index provided"
+  )
+})
+
+test_that("missing year triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", survey = "acs5"),
+    "A 'year' value must be provided"
+  )
+})
+
+test_that("invalid year triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2000, survey = "acs5"),
+    "The 'year' value provided is invalid"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = "ham", survey = "acs5"),
+    "The 'year' value provided is invalid"
+  )
+})
+
+test_that("svi14/svi20 year constraint triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "svi14", year = 2010, survey = "acs5"),
+    "not valid for 2014 or 2020 SVI specifications"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "svi20", year = 2011, survey = "acs5"),
+    "not valid for 2014 or 2020 SVI specifications"
+  )
+})
+
+test_that("svi20s year constraint triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "svi20s", year = 2018, survey = "acs5"),
+    "not valid for the 2020 SVI specification with the alternate single parent"
+  )
+})
+
+test_that("invalid survey triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "ham"),
+    "The 'survey' value provided is not valid"
+  )
+})
+
+test_that("discontinued acs3 survey triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs3"),
+    "The 'acs3' survey was discontinued after 2013"
+  )
+})
+
+test_that("non-logical return_percentiles triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  return_percentiles = "yes"),
+    "Please provide a logical scalar for 'return_percentiles'"
+  )
+})
+
+test_that("non-logical keep_subscales triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  keep_subscales = "yes"),
+    "Please provide a logical scalar for 'keep_subscales'"
+  )
+})
+
+test_that("non-logical keep_components triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  keep_components = "yes"),
+    "Please provide a logical scalar for 'keep_components'"
+  )
+})
+
+test_that("territory in state argument triggers error", {
+  # Note: validate_state converts abbreviations to FIPS codes before the
+
+  # territory check runs, so we pass the FIPS code directly to trigger the
+  # correct validation path. This is a known issue in the package.
+  skip("Territory validation compares FIPS against abbreviations - known bug")
+})
+
+test_that("state and county both specified triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  state = "MO", county = "29510"),
+    "Please choose values for either 'state' or 'county' but not both"
+  )
+})
+
+test_that("non-logical puerto_rico triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  puerto_rico = "yes"),
+    "Please provide a logical scalar for 'puerto_rico'"
+  )
+})
+
+test_that("invalid output triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  output = "ham"),
+    "The 'output' requested is invalid"
+  )
+})
+
+test_that("tidy output with keep_components triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  output = "tidy", keep_components = TRUE),
+    "Tidy output is only available if 'keep_components' is 'FALSE'"
+  )
+})
+
+test_that("non-logical zcta_cb triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  zcta_cb = "yes"),
+    "Please provide a logical scalar for 'zcta_cb'"
+  )
+})
+
+test_that("non-logical shift_geo triggers error", {
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
+                  shift_geo = "yes"),
+    "Please provide a logical scalar for 'shift_geo'"
+  )
+})

--- a/tests/testthat/test_dep_map_breaks.R
+++ b/tests/testthat/test_dep_map_breaks.R
@@ -1,0 +1,190 @@
+context("test dep_map_breaks function")
+
+# setup ------------------------------------------------
+
+test_data <- function() {
+  sample_df <- dep_sample_data(index = "ndi_m")
+  dep_calc_index(sample_df, geography = "county", index = "ndi_m", year = 2022)
+}
+
+# test errors ------------------------------------------------
+
+test_that("invalid return argument triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
+                   style = "fisher", return = "ham"),
+    "The 'return' argument only accepts 'col' or 'breaks' as arguments."
+  )
+})
+
+test_that("supplying breaks and return = 'breaks' triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks",
+                   breaks = c(0, 25, 50, 75, 100), return = "breaks"),
+    "Returning breaks is only possible if breaks are not first supplied."
+  )
+})
+
+test_that("missing both classes/style and breaks triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks"),
+    "Values must be supplied for both 'classes' and 'style', or 'breaks'."
+  )
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5),
+    "Values must be supplied for both 'classes' and 'style', or 'breaks'."
+  )
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", style = "fisher"),
+    "Values must be supplied for both 'classes' and 'style', or 'breaks'."
+  )
+})
+
+test_that("missing new_var with return = 'col' triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", classes = 5, style = "fisher"),
+    "A variable name for a new column must be supplied if 'return' is 'col'."
+  )
+})
+
+test_that("nonexistent source variable triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "FAKE_VAR", new_var = "breaks", classes = 5,
+                   style = "fisher"),
+    "The variable supplied for 'var' cannot be found in the data object."
+  )
+})
+
+test_that("non-numeric source variable triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NAME", new_var = "breaks", classes = 5,
+                   style = "fisher"),
+    "The variable supplied for 'var' is not formatted as a numeric or integer variable."
+  )
+})
+
+test_that("non-numeric classes triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = "five",
+                   style = "fisher"),
+    "The value supplied for 'classes' is not formatted as a numeric or integer value."
+  )
+})
+
+test_that("invalid style triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
+                   style = "invalid_style"),
+    "The style provided is not supported"
+  )
+})
+
+test_that("non-numeric breaks triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks",
+                   breaks = c("a", "b", "c")),
+    "The vector supplied for 'breaks' is not formatted as a numeric or integer vector."
+  )
+})
+
+test_that("too few breaks triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", breaks = c(0, 100)),
+    "At least three values must be supplied"
+  )
+})
+
+test_that("non-numeric sig_digits triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
+                   style = "fisher", sig_digits = "two"),
+    "The value supplied for 'sig_digits' is not formatted as a numeric or integer value."
+  )
+})
+
+test_that("non-logical show_warnings triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
+                   style = "fisher", show_warnings = "yes"),
+    "The value supplied for 'show_warnings' is not valid"
+  )
+})
+
+# test happy paths ------------------------------------------------
+
+test_that("return = 'col' adds a factor column after the source variable", {
+  df <- test_data()
+  result <- dep_map_breaks(df, var = "NDI_M", new_var = "map_breaks",
+                           classes = 5, style = "fisher")
+
+  expect_true("map_breaks" %in% names(result))
+  expect_s3_class(result[["map_breaks"]], "factor")
+  expect_equal(nlevels(result[["map_breaks"]]), 5)
+
+  # new column should be placed after the source variable
+
+  var_pos <- which(names(result) == "NDI_M")
+  new_pos <- which(names(result) == "map_breaks")
+  expect_equal(new_pos, var_pos + 1)
+})
+
+test_that("return = 'breaks' returns a numeric vector", {
+  df <- test_data()
+  result <- dep_map_breaks(df, var = "NDI_M", new_var = "breaks",
+                           classes = 5, style = "fisher", return = "breaks")
+
+  expect_true(is.numeric(result))
+  expect_equal(length(result), 6)  # 5 classes = 6 break points
+})
+
+test_that("manual breaks work correctly", {
+  df <- test_data()
+  brks <- c(0, 25, 50, 75, max(df$NDI_M, na.rm = TRUE))
+  result <- dep_map_breaks(df, var = "NDI_M", new_var = "map_breaks",
+                           breaks = brks)
+
+  expect_true("map_breaks" %in% names(result))
+  expect_s3_class(result[["map_breaks"]], "factor")
+  # 4 break points create 3 intervals but cut() with include.lowest may differ
+
+  expect_equal(nlevels(result[["map_breaks"]]), length(brks) - 1)
+})
+
+test_that("quoted variable names work", {
+  df <- test_data()
+  result <- dep_map_breaks(df, var = "NDI_M", new_var = "map_breaks",
+                           classes = 4, style = "quantile")
+
+  expect_true("map_breaks" %in% names(result))
+  expect_equal(nlevels(result[["map_breaks"]]), 4)
+})
+
+test_that("unquoted variable names work", {
+  df <- test_data()
+  result <- dep_map_breaks(df, var = NDI_M, new_var = map_breaks_uq,
+                           classes = 4, style = "quantile")
+
+  expect_true("map_breaks_uq" %in% names(result))
+})
+
+test_that("show_warnings = FALSE suppresses warnings", {
+  df <- test_data()
+  # Should not produce warnings
+  expect_warning(
+    dep_map_breaks(df, var = "NDI_M", new_var = "map_breaks", classes = 5,
+                   style = "fisher", show_warnings = FALSE),
+    NA
+  )
+})

--- a/tests/testthat/test_dep_percentiles.R
+++ b/tests/testthat/test_dep_percentiles.R
@@ -1,0 +1,85 @@
+context("test dep_percentiles function")
+
+# setup ------------------------------------------------
+
+test_data <- function() {
+  dep_sample_data(index = "ndi_m")
+}
+
+# test errors ------------------------------------------------
+
+test_that("non-data-frame .data triggers error", {
+  expect_error(
+    dep_percentiles(.data = "not a data frame", source_var = x, new_var = y),
+    "The '.data' object provided is not a data frame"
+  )
+})
+
+test_that("nonexistent source_var triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_percentiles(df, source_var = FAKE_VAR, new_var = pctile),
+    "The given 'source_var' column is not found in your data object."
+  )
+})
+
+# test happy paths ------------------------------------------------
+
+test_that("dep_percentiles creates a new variable with percentile ranks", {
+  df <- test_data()
+  result <- dep_percentiles(df, source_var = B06009_001E, new_var = pop_pctile)
+
+  expect_true("pop_pctile" %in% names(result))
+  expect_true(is.numeric(result$pop_pctile))
+  # Percentiles should range from 0 to 1
+  expect_true(min(result$pop_pctile, na.rm = TRUE) >= 0)
+  expect_true(max(result$pop_pctile, na.rm = TRUE) <= 1)
+})
+
+test_that("dep_percentiles overwrites source when new_var is omitted", {
+  df <- test_data()
+  original_vals <- df$B06009_001E
+  result <- dep_percentiles(df, source_var = B06009_001E)
+
+  # The column should still exist but contain percentile values
+  expect_true("B06009_001E" %in% names(result))
+  # Values should be between 0 and 1 (percentile ranks)
+  expect_true(max(result$B06009_001E, na.rm = TRUE) <= 1)
+})
+
+test_that("existing new_var produces a warning", {
+  df <- test_data()
+  expect_warning(
+    dep_percentiles(df, source_var = B06009_001E, new_var = GEOID),
+    "The given 'new_var' column exists in your data and will be overwritten."
+  )
+})
+
+test_that("dep_percent_rank produces correct values for simple case", {
+  # Test the internal helper directly
+  x <- c(10, 20, 30, 40, 50)
+  result <- deprivateR:::dep_percent_rank(x)
+
+  expect_equal(length(result), 5)
+  expect_equal(result[1], 0)    # min should be 0
+  expect_equal(result[5], 1)    # max should be 1
+  # Values should be monotonically increasing for sorted input
+  expect_true(all(diff(result) >= 0))
+})
+
+test_that("dep_percent_rank handles NA values", {
+  x <- c(10, NA, 30, 40, 50)
+  result <- deprivateR:::dep_percent_rank(x)
+
+  expect_equal(length(result), 5)
+  expect_true(is.na(result[2]))
+  expect_false(any(is.na(result[-2])))
+})
+
+test_that("dep_percent_rank handles ties", {
+  x <- c(10, 10, 30, 40, 50)
+  result <- deprivateR:::dep_percent_rank(x)
+
+  # Tied values should get the same rank
+  expect_equal(result[1], result[2])
+})

--- a/tests/testthat/test_dep_quantiles.R
+++ b/tests/testthat/test_dep_quantiles.R
@@ -1,0 +1,133 @@
+context("test dep_quantiles function")
+
+# setup ------------------------------------------------
+
+test_data <- function() {
+  sample_df <- dep_sample_data(index = "ndi_m")
+  dep_calc_index(sample_df, geography = "county", index = "ndi_m", year = 2022,
+                 return_percentiles = TRUE)
+}
+
+# test errors ------------------------------------------------
+
+test_that("non-data-frame .data triggers error", {
+  expect_error(
+    dep_quantiles(.data = "not a data frame", source_var = "x", new_var = "y"),
+    "The object passed to the '.data' argument must be a data frame."
+  )
+})
+
+test_that("nonexistent source_var triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_quantiles(df, source_var = "FAKE_VAR", new_var = "q"),
+    "The variable name passed to the 'source_var' argument does not exist"
+  )
+})
+
+test_that("non-integer n triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_quantiles(df, source_var = NDI_M, new_var = q, n = 4),
+    "The 'n' argument must be an integer"
+  )
+})
+
+test_that("n < 2L triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_quantiles(df, source_var = NDI_M, new_var = q, n = 1L),
+    "The 'n' argument must be 2L or greater"
+  )
+})
+
+test_that("invalid return triggers error", {
+  df <- test_data()
+  expect_error(
+    dep_quantiles(df, source_var = NDI_M, new_var = q, return = "ham"),
+    "The 'return' argument must be either 'label' or 'factor'"
+  )
+})
+
+test_that("existing new_var produces a warning", {
+  df <- test_data()
+  expect_warning(
+    dep_quantiles(df, source_var = NDI_M, new_var = NDI_M),
+    "already exists in the data"
+  )
+})
+
+# test happy paths - labels ------------------------------------------------
+
+test_that("default quartiles return correct labels", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = NDI_M, new_var = ndi_quartiles)
+
+  expect_true("ndi_quartiles" %in% names(result))
+  labels <- unique(sort(result$ndi_quartiles))
+  expect_equal(length(labels), 4)
+  expect_true(grepl("Lowest Quartile", labels[1]))
+  expect_true(grepl("Highest Quartile", labels[4]))
+})
+
+test_that("n = 2L returns median split labels", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = NDI_M, new_var = ndi_median, n = 2L)
+
+  labels <- unique(sort(result$ndi_median))
+  expect_equal(length(labels), 2)
+  expect_true(grepl("Lower Than Median", labels[1]))
+  expect_true(grepl("Greater Than Median", labels[2]))
+})
+
+test_that("n = 3L returns tertile labels", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = NDI_M, new_var = ndi_tertiles, n = 3L)
+
+  labels <- unique(sort(result$ndi_tertiles))
+  expect_equal(length(labels), 3)
+  expect_true(grepl("Lowest Tertile", labels[1]))
+  expect_true(grepl("Middle Tertile", labels[2]))
+  expect_true(grepl("Highest Tertile", labels[3]))
+})
+
+test_that("n = 5L returns quintile labels", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = NDI_M, new_var = ndi_quintiles, n = 5L)
+
+  labels <- unique(sort(result$ndi_quintiles))
+  expect_equal(length(labels), 5)
+  expect_true(grepl("Lowest Quintile", labels[1]))
+  expect_true(grepl("Highest Quintile", labels[5]))
+})
+
+test_that("n = 10L returns decile labels", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = NDI_M, new_var = ndi_deciles, n = 10L)
+
+  labels <- unique(result$ndi_deciles)
+  expect_equal(length(labels), 10)
+  expect_true(any(grepl("Lowest Decile", labels)))
+  expect_true(any(grepl("Highest Decile", labels)))
+})
+
+# test happy paths - factor ------------------------------------------------
+
+test_that("return = 'factor' returns a factor column", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = NDI_M, new_var = ndi_q_factor,
+                          n = 4L, return = "factor")
+
+  expect_true("ndi_q_factor" %in% names(result))
+  expect_s3_class(result[["ndi_q_factor"]], "factor")
+  expect_equal(nlevels(result[["ndi_q_factor"]]), 4)
+})
+
+# test quoted vs unquoted ------------------------------------------------
+
+test_that("quoted variable names work", {
+  df <- test_data()
+  result <- dep_quantiles(df, source_var = "NDI_M", new_var = "ndi_q_quoted")
+
+  expect_true("ndi_q_quoted" %in% names(result))
+})

--- a/tests/testthat/test_dep_utils.R
+++ b/tests/testthat/test_dep_utils.R
@@ -1,0 +1,80 @@
+context("test internal utility functions")
+
+# test dep_quantile_label ------------------------------------------------
+
+test_that("dep_quantile_label returns correct labels", {
+  expect_equal(deprivateR:::dep_quantile_label(4L), "Quartile")
+  expect_equal(deprivateR:::dep_quantile_label(5L), "Quintile")
+  expect_equal(deprivateR:::dep_quantile_label(6L), "Sextile")
+  expect_equal(deprivateR:::dep_quantile_label(7L), "Septile")
+  expect_equal(deprivateR:::dep_quantile_label(8L), "Octile")
+  expect_equal(deprivateR:::dep_quantile_label(9L), "Nonile")
+  expect_equal(deprivateR:::dep_quantile_label(10L), "Decile")
+})
+
+test_that("dep_quantile_label returns generic for unsupported values", {
+  expect_equal(deprivateR:::dep_quantile_label(11L), "Quantile")
+  expect_equal(deprivateR:::dep_quantile_label(20L), "Quantile")
+})
+
+# test dep_ordinal ------------------------------------------------
+
+test_that("dep_ordinal returns correctly formatted ordinals", {
+  result_2 <- deprivateR:::dep_ordinal(2)
+  result_3 <- deprivateR:::dep_ordinal(3)
+
+  # Should be title-cased
+  expect_true(grepl("^[A-Z]", result_2))
+  expect_true(grepl("^[A-Z]", result_3))
+  # Should contain ordinal suffix
+  expect_true(grepl("nd$", result_2, ignore.case = TRUE))
+  expect_true(grepl("rd$", result_3, ignore.case = TRUE))
+})
+
+# test validate_state ------------------------------------------------
+
+test_that("validate_state handles valid FIPS codes", {
+  result <- deprivateR:::validate_state("29", .msg = FALSE)
+  expect_equal(result, "29")
+})
+
+test_that("validate_state handles single-digit FIPS codes", {
+  result <- deprivateR:::validate_state("6", .msg = FALSE)
+  expect_equal(result, "06")
+})
+
+test_that("validate_state handles valid abbreviations", {
+  result <- deprivateR:::validate_state("mo", .msg = FALSE)
+  expect_equal(result, "29")
+})
+
+test_that("validate_state returns NULL for invalid input", {
+  expect_warning(
+    result <- deprivateR:::validate_state("ZZ", .msg = FALSE),
+    "is not a valid FIPS code"
+  )
+  expect_null(result)
+})
+
+test_that("validate_state returns NULL for NULL input", {
+  result <- deprivateR:::validate_state(NULL, .msg = FALSE)
+  expect_null(result)
+})
+
+# test pivot_demos ------------------------------------------------
+
+test_that("pivot_demos aggregates estimate and moe columns", {
+  # Create minimal test data mimicking Census format
+  test_df <- tibble::tibble(
+    GEOID = rep(c("29001", "29003"), each = 1),
+    B01001_001E = c(100, 200),
+    B01001_001M = c(10, 20)
+  )
+
+  result <- deprivateR:::pivot_demos(test_df, vars = c("B01001_001E", "B01001_001M"))
+
+  expect_true("GEOID" %in% names(result))
+  expect_true("estimate" %in% names(result))
+  expect_true("moe" %in% names(result))
+  expect_equal(nrow(result), 2)
+})


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for all exported functions that previously lacked test coverage: `dep_get_index`, `dep_map_breaks`, `dep_quantiles`, `dep_percentiles`, and internal utility helpers. Test count goes from 10 blocks / 3 files to **179 assertions / 8 files**.

## Implementation

- **`test_dep_get_index.R`** — 21 assertions covering all input validation error paths (offline, no API key needed)
- **`test_dep_map_breaks.R`** — 27 assertions: error paths + happy-path computation (auto breaks, manual breaks, quoted/unquoted vars)
- **`test_dep_quantiles.R`** — 27 assertions: error paths + label correctness for n=2L through n=10L + factor return mode
- **`test_dep_percentiles.R`** — 17 assertions: error paths + percentile rank correctness, NA handling, tie handling
- **`test_dep_utils.R`** — 23 assertions: `dep_quantile_label`, `dep_ordinal`, `validate_state`, `pivot_demos`

All tests use bundled sample data via `dep_sample_data()` + `dep_calc_index()` — no Census API key required.

## Testing

```
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 179 ]
```

1 intentional skip: territory validation has a pre-existing bug (FIPS codes compared against abbreviations).

## Closes

Closes #3

## Notes

- No R/ source code was modified — this is a test-only PR.
- Discovered pre-existing bug in `dep_get_index` territory validation (documented in skipped test with explanation). Filed as known issue for future work.
