### PR TITLE
feat: migrate all stop/warning/message calls to cli equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Migrated all `stop()`/`warning()`/`message()` calls to `cli::cli_abort()`/`cli::cli_warn()`/`cli::cli_inform()` for tidyverse-style formatted error messages (#28)
 - Bumped minimum R version from 4.1 to 4.4 (required by Matrix package dependency chain)
 - Bumped minimum R version from 3.5 to 4.1 (#5)
 - Removed stale `CRAN-SUBMISSION` file from v0.1.0 (#7)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Language: en-US
 LazyData: true
 Imports:
     classInt,
+    cli,
     dplyr,
     english,
     ndi,

--- a/R/dep_build_varlist.R
+++ b/R/dep_build_varlist.R
@@ -33,47 +33,80 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
 
   # check inputs
   if (missing(geography) == TRUE) {
-    stop("A level of geography must be provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+    cli::cli_abort(c(
+      "A {.arg geography} value must be provided.",
+      "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
+    ))
   }
 
   if (geography %in% c("county", "zcta3", "zcta5", "tract") == FALSE){
-    stop("Invalid level of geography provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+    cli::cli_abort(c(
+      "Invalid {.arg geography} provided: {.val {geography}}.",
+      "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
+    ))
   }
 
   if (missing(index) == TRUE){
-    stop("A 'index' value must be provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "A {.arg index} value must be provided.",
+      "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE){
-    stop("Invalid index provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "Invalid {.arg index} provided: {.val {index}}.",
+      "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (missing(year) == TRUE){
-    stop("A 'year' value must be provided. Please choose a numeric value between 2010 and 2022.")
+    cli::cli_abort(c(
+      "A {.arg year} value must be provided.",
+      "i" = "Choose a numeric value between {.val 2010} and {.val 2022}."
+    ))
   }
 
   if (is.numeric(year) == FALSE | (min(year) < 2010 | max(year) > 2022)){
-    stop("The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+    cli::cli_abort(c(
+      "Invalid {.arg year} provided: {.val {year}}.",
+      "i" = "Provide a numeric value between {.val 2010} and {.val 2022}."
+    ))
   }
 
   if (any(index %in% c("svi14", "svi20")) == TRUE & min(year) < 2012){
-    stop("The 'year' value provided is not valid for 2014 or 2020 SVI specifications. Each of those can be calculated from 2012 onward. Please use 'svi10' for 2010 or 2011.")
+    cli::cli_abort(c(
+      "Invalid {.arg year} provided for {.arg index}: {.val {year}}.",
+      "i" = "{.val svi14} and {.val svi20} can be calculated from {.val 2012} onward. Use {.val svi10} for {.val 2010} or {.val 2011}."
+    ))
   }
 
   if (any(index == "svi20s") == TRUE & min(year) < 2019){
-    stop("The 'year' value provided is not valid for the 2020 SVI specification with the alternate single parent measure. This can only be calculated for 2019 onward.")
+    cli::cli_abort(c(
+      "Invalid {.arg year} provided for {.arg index}: {.val {year}}.",
+      "i" = "{.val svi20s} can only be calculated from {.val 2019} onward."
+    ))
   }
 
   if (survey %in% c("acs1", "acs3", "acs5") == FALSE){
-    stop("The 'survey' value provided is not valid. Please choose one of 'acs1', 'acs3', or 'acs5'.")
+    cli::cli_abort(c(
+      "Invalid {.arg survey} provided: {.val {survey}}.",
+      "i" = "Choose one of: {.val acs1}, {.val acs3}, or {.val acs5}."
+    ))
   }
 
   if (survey == "acs3" & year > 2013){
-    stop("The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+    cli::cli_abort(c(
+      "The {.val acs3} survey is not available after {.val 2013}.",
+      "i" = "Choose one of: {.val acs1} or {.val acs5}."
+    ))
   }
 
   if (output %in% c("vector", "tibble") == FALSE){
-    stop("The 'output' value provided is not valid. Please choose one of 'vector' or 'tibble'.")
+    cli::cli_abort(c(
+      "Invalid {.arg output} provided: {.val {output}}.",
+      "i" = "Choose one of: {.val vector} or {.val tibble}."
+    ))
   }
 
   ## gini

--- a/R/dep_calc_index.R
+++ b/R/dep_calc_index.R
@@ -78,63 +78,99 @@ dep_calc_index <- function(.data, geography, index, year, survey = "acs5",
 
   # check inputs
   if (missing(geography) == TRUE) {
-    stop("A level of geography must be provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+    cli::cli_abort(c(
+      "A {.arg geography} value must be provided.",
+      "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
+    ))
   }
 
   if (geography %in% c("county", "zcta3", "zcta5", "tract") == FALSE){
-    stop("Invalid level of geography provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+    cli::cli_abort(c(
+      "Invalid {.arg geography} provided: {.val {geography}}.",
+      "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
+    ))
   }
 
   if (missing(index) == TRUE){
-    stop("A 'index' value must be provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "A {.arg index} value must be provided.",
+      "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE){
-    stop("Invalid index provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "Invalid {.arg index} provided: {.val {index}}.",
+      "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (missing(year) == TRUE){
-    stop("A 'year' value must be provided. Please choose a numeric value between 2010 and 2021.")
+    cli::cli_abort(c(
+      "A {.arg year} value must be provided.",
+      "i" = "Choose a numeric value between 2010 and 2022."
+    ))
   }
 
   if (is.numeric(year) == FALSE | (min(year) < 2010 | max(year) > 2022)){
-    stop("The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+    cli::cli_abort(c(
+      "The {.arg year} value provided is invalid.",
+      "i" = "Please provide a numeric value between 2010 and 2022."
+    ))
   }
 
   if (any(index %in% c("svi14", "svi20")) == TRUE & min(year) < 2012){
-    stop("The 'year' value provided is not valid for 2014 or 2020 SVI specifications. Each of those can be calculated from 2012 onward. Please use 'svi10' for 2010 or 2011.")
+    cli::cli_abort(c(
+      "The {.arg year} value is not valid for 2014 or 2020 SVI specifications.",
+      "i" = "Each of those can be calculated from 2012 onward. Use {.val svi10} for 2010 or 2011."
+    ))
   }
 
   if (any(index == "svi20s") == TRUE & min(year) < 2019){
-    stop("The 'year' value provided is not valid for the 2020 SVI specification with the alternate single parent measure. This can only be calculated for 2019 onward.")
+    cli::cli_abort(c(
+      "The {.arg year} value is not valid for the 2020 SVI specification with the alternate single parent measure.",
+      "i" = "This can only be calculated for 2019 onward."
+    ))
   }
 
   if (survey %in% c("acs1", "acs3", "acs5") == FALSE){
-    stop("The 'survey' value provided is not valid. Please choose one of 'acs1', 'acs3', or 'acs5'.")
+    cli::cli_abort(c(
+      "The {.arg survey} value provided is not valid: {.val {survey}}.",
+      "i" = "Choose one of: {.val acs1}, {.val acs3}, or {.val acs5}."
+    ))
   }
 
   if (survey == "acs3" & year > 2013){
-    stop("The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+    cli::cli_abort(c(
+      "The {.val acs3} survey was discontinued after 2013.",
+      "i" = "Please select one of {.val acs1} or {.val acs5}."
+    ))
   }
 
   if (is.logical(return_percentiles) == FALSE){
-    stop("Please provide a logical scalar for 'return_percentiles'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg return_percentiles}.")
   }
 
   if (is.logical(keep_subscales) == FALSE){
-    stop("Please provide a logical scalar for 'keep_subscales'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg keep_subscales}.")
   }
 
   if (is.logical(keep_components) == FALSE){
-    stop("Please provide a logical scalar for 'keep_components'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg keep_components}.")
   }
 
   if (output %in% c("wide", "tidy") == FALSE){
-    stop("The 'output' value provided is not valid. Please choose one of 'wide' or 'tidy'.")
+    cli::cli_abort(c(
+      "The {.arg output} value provided is not valid: {.val {output}}.",
+      "i" = "Choose one of: {.val wide} or {.val tidy}."
+    ))
   }
 
   if (output == "tidy" & keep_components == TRUE){
-    stop("The 'output' requested is invalid. Tidy output is only available if 'keep_components' is 'FALSE'.")
+    cli::cli_abort(c(
+      "The {.arg output} requested is invalid.",
+      "i" = "Tidy output is only available if {.arg keep_components} is {.code FALSE}."
+    ))
   }
 
   # prep extra inputs
@@ -170,7 +206,10 @@ dep_calc_index <- function(.data, geography, index, year, survey = "acs5",
 
   ## test variable names
   if (all(var_expected %in% names(.data)) == FALSE){
-    stop("Variables necessary for the given year(s) and index/indicies are missing. Please double check your input data.")
+    cli::cli_abort(c(
+      "Variables necessary for the given year(s) and index/indices are missing.",
+      "i" = "Please double check your input data."
+    ))
   }
 
   # split data frame
@@ -215,7 +254,7 @@ dep_calc_index <- function(.data, geography, index, year, survey = "acs5",
 
   ## throw warning
   if (any(out_names %in% names(.data)) == TRUE){
-    warning("Variable conflicts present between input data and deprivation output. Only output returned.")
+    cli::cli_warn("Variable conflicts present between input data and deprivation output. Only output returned.")
   } else if (any(out_names %in% names(.data)) == FALSE){
     if (length(year) > 1){
       out <- merge(x = .data, y = out, by = c("GEOID", "YEAR"), all.x = TRUE)

--- a/R/dep_get_data.R
+++ b/R/dep_get_data.R
@@ -163,7 +163,7 @@ dep_get_zcta5 <- function(varlist, year, survey, state, county,
                                         key = key,
                                         debug = debug)
   } else if (debug == "test"){
-    stop("testing debug mode not enabled yet!")
+    cli::cli_abort("Testing debug mode not enabled yet.")
   }
 
   ## optionally filter based on zcta
@@ -262,7 +262,7 @@ dep_get_zcta3 <- function(varlist, year, survey, state, county,
                                         key = key,
                                         debug = debug)
   } else if (debug == "test"){
-    stop("testing debug mode not enabled yet!")
+    cli::cli_abort("Testing debug mode not enabled yet.")
   }
 
   ## optionally filter based on zcta
@@ -305,7 +305,7 @@ dep_get_zcta3 <- function(varlist, year, survey, state, county,
                                  zcta = zcta, key = key,
                                  debug = debug)
   } else if (debug == "test"){
-    stop("testing debug mode not enabled yet!")
+    cli::cli_abort("Testing debug mode not enabled yet.")
   }
 
   ### rename id
@@ -411,7 +411,7 @@ dep_get_census <- function(geography, varlist, year, survey, state, county,
                                show_call = TRUE,
                                key = key)
   } else if (debug == "test"){
-    stop("testing debug mode not enabled yet!")
+    cli::cli_abort("Testing debug mode not enabled yet.")
   }
 
   ## return output

--- a/R/dep_get_index.R
+++ b/R/dep_get_index.R
@@ -174,55 +174,85 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
 
   # check inputs
   if (missing(geography) == TRUE) {
-    stop("A level of geography must be provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+    cli::cli_abort(c(
+      "A {.arg geography} value must be provided.",
+      "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
+    ))
   }
 
   if (geography %in% c("county", "zcta3", "zcta5", "tract") == FALSE){
-    stop("Invalid level of geography provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+    cli::cli_abort(c(
+      "Invalid {.arg geography} provided: {.val {geography}}.",
+      "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
+    ))
   }
 
   if (missing(index) == TRUE){
-    stop("A 'index' value must be provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "A {.arg index} value must be provided.",
+      "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE){
-    stop("Invalid index provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', or 'svi20'.")
+    cli::cli_abort(c(
+      "Invalid {.arg index} provided: {.val {index}}.",
+      "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (missing(year) == TRUE){
-    stop("A 'year' value must be provided. Please choose a numeric value between 2010 and 2022.")
+    cli::cli_abort(c(
+      "A {.arg year} value must be provided.",
+      "i" = "Choose a numeric value between 2010 and 2022."
+    ))
   }
 
   if (is.numeric(year) == FALSE | (min(year) < 2010 | max(year) > 2022)){
-    stop("The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+    cli::cli_abort(c(
+      "The {.arg year} value provided is invalid.",
+      "i" = "Please provide a numeric value between 2010 and 2022."
+    ))
   }
 
   if (any(index %in% c("svi14", "svi20")) == TRUE & min(year) < 2012){
-    stop("The 'year' value provided is not valid for 2014 or 2020 SVI specifications. Each of those can be calculated from 2012 onward. Please use 'svi10' for 2010 or 2011.")
+    cli::cli_abort(c(
+      "The {.arg year} value is not valid for 2014 or 2020 SVI specifications.",
+      "i" = "Each of those can be calculated from 2012 onward. Use {.val svi10} for 2010 or 2011."
+    ))
   }
 
   if (any(index == "svi20s") == TRUE & min(year) < 2019){
-    stop("The 'year' value provided is not valid for the 2020 SVI specification with the alternate single parent measure. This can only be calculated for 2019 onward.")
+    cli::cli_abort(c(
+      "The {.arg year} value is not valid for the 2020 SVI specification with the alternate single parent measure.",
+      "i" = "This can only be calculated for 2019 onward."
+    ))
   }
 
   if (survey %in% c("acs1", "acs3", "acs5") == FALSE){
-    stop("The 'survey' value provided is not valid. Please choose one of 'acs1', 'acs3', or 'acs5'.")
+    cli::cli_abort(c(
+      "The {.arg survey} value provided is not valid: {.val {survey}}.",
+      "i" = "Choose one of: {.val acs1}, {.val acs3}, or {.val acs5}."
+    ))
   }
 
   if (survey == "acs3" & max(year) > 2013){
-    stop("The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+    cli::cli_abort(c(
+      "The {.val acs3} survey was discontinued after 2013.",
+      "i" = "Please select one of {.val acs1} or {.val acs5}."
+    ))
   }
 
   if (is.logical(return_percentiles) == FALSE){
-    stop("Please provide a logical scalar for 'return_percentiles'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg return_percentiles}.")
   }
 
   if (is.logical(keep_subscales) == FALSE){
-    stop("Please provide a logical scalar for 'keep_subscales'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg keep_subscales}.")
   }
 
   if (is.logical(keep_components) == FALSE){
-    stop("Please provide a logical scalar for 'keep_components'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg keep_components}.")
   }
 
   if (is.null(state) == FALSE){
@@ -230,39 +260,53 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
   }
 
   if (any(state %in% c("AS", "GU", "MP", "PR", "VI")) == TRUE){
-    stop("Territories cannot be specified using the 'state' argument. Use the 'puerto_rico' argument for Puerto Rico. Deprivation measures are not available for other territories.")
+    cli::cli_abort(c(
+      "Territories cannot be specified using the {.arg state} argument.",
+      "i" = "Use the {.arg puerto_rico} argument for Puerto Rico.",
+      "i" = "Deprivation measures are not available for other territories."
+    ))
   }
 
   if (is.null(county) == FALSE & is.null(state) == FALSE){
-    stop("Please choose values for either 'state' or 'county' but not both.")
+    cli::cli_abort("Please choose values for either {.arg state} or {.arg county} but not both.")
   }
 
   if (is.logical(puerto_rico) == FALSE){
-    stop("Please provide a logical scalar for 'puerto_rico'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg puerto_rico}.")
   }
 
   ## need to check for zcta3_method
 
   if (geography != "zcta5" & is.null(zcta) == FALSE){
-    warning("The 'zcta' argument was ignored because the geography requested is not 'zcta5'.")
+    cli::cli_warn("The {.arg zcta} argument was ignored because the geography requested is not {.val zcta5}.")
   } else if (geography == "zcta5" & is.null(zcta) == FALSE){
     valid <- zippeR::zi_validate(zcta, style = geography)
 
     if (valid == FALSE){
-      stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zippeR::zi_validate()' with the 'verbose = TRUE' option to investgiate further. The 'zippeR::zi_repair()' function may be used to address isses.")
+      cli::cli_abort(c(
+        "ZCTA data passed to the {.arg zcta} argument are invalid.",
+        "i" = "Use {.fn zippeR::zi_validate} with {.code verbose = TRUE} to investigate further.",
+        "i" = "The {.fn zippeR::zi_repair} function may be used to address issues."
+      ))
     }
   }
 
   if (output %in% c("tidy", "wide", "sf") == FALSE){
-    stop("The 'output' requested is invalid. Please choose one of 'tidy', 'wide', or 'sf'.")
+    cli::cli_abort(c(
+      "The {.arg output} requested is invalid: {.val {output}}.",
+      "i" = "Choose one of: {.val tidy}, {.val wide}, or {.val sf}."
+    ))
   }
 
   if (output == "tidy" & keep_components == TRUE){
-    stop("The 'output' requested is invalid. Tidy output is only available if 'keep_components' is 'FALSE'.")
+    cli::cli_abort(c(
+      "The {.arg output} requested is invalid.",
+      "i" = "Tidy output is only available if {.arg keep_components} is {.code FALSE}."
+    ))
   }
 
   if (is.logical(zcta_cb) == FALSE){
-    stop("Please provide a logical scalar for 'zcta_cb'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg zcta_cb}.")
   }
 
   # if (is.logical(keep_geo_vars) == FALSE){
@@ -271,7 +315,7 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
   keep_geo_vars <- FALSE
 
   if (is.logical(shift_geo) == FALSE){
-    stop("Please provide a logical scalar for 'shift_geo'.")
+    cli::cli_abort("Please provide a logical scalar for {.arg shift_geo}.")
   }
 
   # if (units %in% c("mi2", "km2") == FALSE){

--- a/R/dep_map_breaks.R
+++ b/R/dep_map_breaks.R
@@ -65,20 +65,20 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
 
   # check return
   if (return %in% c("col", "breaks") == FALSE){
-    stop("The 'return' argument only accepts 'col' or 'breaks' as arguments.")
+    cli::cli_abort("{.arg return} only accepts {.val col} or {.val breaks}.")
   }
 
   # check for correct combination of parameters
   if (missing(breaks) == FALSE & return == "breaks"){
-    stop("Returning breaks is only possible if breaks are not first supplied.")
+    cli::cli_abort(c("Returning breaks is only possible when {.arg breaks} is not supplied.", "i" = "Omit {.arg breaks} or set {.arg return} to {.val col}."))
   }
 
   if ((missing(classes) == TRUE | missing(style) == TRUE) & missing(breaks) == TRUE){
-    stop("Values must be supplied for both 'classes' and 'style', or 'breaks'.")
+    cli::cli_abort(c("Supply values for both {.arg classes} and {.arg style}, or supply {.arg breaks}.", "i" = "Use {.arg classes} with {.arg style} to compute breaks, or provide {.arg breaks} directly."))
   }
 
   if (return == "col" & missing(new_var) == TRUE){
-    stop("A variable name for a new column must be supplied if 'return' is 'col'.")
+    cli::cli_abort(c("A name for {.arg new_var} must be supplied when {.arg return} is {.val col}.", "i" = "Provide {.arg new_var} or set {.arg return} to {.val breaks}."))
   }
 
   # save parameters to list
@@ -105,17 +105,17 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
 
   # check that source variable exists and is numeric
   if (refQ %in% names(.data) == FALSE){
-    stop("The variable supplied for 'var' cannot be found in the data object.")
+    cli::cli_abort("The variable supplied for {.arg var} cannot be found in {.arg .data}.")
   }
 
   if (class(.data[[refQ]]) %in% c("numeric", "integer") == FALSE){
-    stop("The variable supplied for 'var' is not formatted as a numeric or integer variable.")
+    cli::cli_abort("The variable supplied for {.arg var} must be numeric or integer.")
   }
 
   # check other arguments
   if (missing(classes) == FALSE){
     if (class(classes) %in% c("numeric", "integer") == FALSE){
-      stop("The value supplied for 'classes' is not formatted as a numeric or integer value.")
+      cli::cli_abort("The value supplied for {.arg classes} must be numeric or integer.")
     }
   }
 
@@ -124,26 +124,26 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
                 "bclust", "fisher", "jenks", "dpih", "headtails", "maximum", "box")
 
     if (style %in% styles == FALSE){
-      stop("The style provided is not supported by classIn::classIntervals. Please select an alternative.")
+      cli::cli_abort(c("{.arg style} is not supported by classInt::classIntervals().", "i" = "Use one of: {.val fixed}, {.val sd}, {.val equal}, {.val pretty}, {.val quantile}, {.val kmeans}, {.val hclust}, {.val bclust}, {.val fisher}, {.val jenks}, {.val dpih}, {.val headtails}, {.val maximum}, or {.val box}."))
     }
   }
 
   if (missing(breaks) == FALSE){
     if (class(breaks) %in% c("numeric", "integer") == FALSE){
-      stop("The vector supplied for 'breaks' is not formatted as a numeric or integer vector.")
+      cli::cli_abort("The vector supplied for {.arg breaks} must be numeric or integer.")
     }
 
     if (length(breaks) < 3){
-      stop("At least three values must be supplied to create a choropleth map with two breaks, which is the minimum supported.")
+      cli::cli_abort(c("At least three values must be supplied for {.arg breaks}.", "i" = "This is the minimum needed to create two choropleth intervals."))
     }
   }
 
   if (class(sig_digits) %in% c("numeric", "integer") == FALSE){
-    stop("The value supplied for 'sig_digits' is not formatted as a numeric or integer value.")
+    cli::cli_abort("The value supplied for {.arg sig_digits} must be numeric or integer.")
   }
 
   if (is.logical(show_warnings) == FALSE){
-    stop("The value supplied for 'show_warnings' is not valid - please provide a logical value.")
+    cli::cli_abort(c("The value supplied for {.arg show_warnings} must be logical.", "i" = "Use either {.val TRUE} or {.val FALSE}."))
   }
 
   # create breaks object, rounded to specified significant digits

--- a/R/dep_quantiles.R
+++ b/R/dep_quantiles.R
@@ -75,27 +75,36 @@ dep_quantiles <- function(.data, source_var, new_var, n = 4L, return = "label"){
 
   # check inputs
   if (!is.data.frame(.data)) {
-    stop("The object passed to the '.data' argument must be a data frame.")
+    cli::cli_abort("The object passed to {.arg .data} must be a data frame.")
   }
 
   if (!refQ %in% names(.data)) {
-    stop("The variable name passed to the 'source_var' argument does not exist in the data.")
+    cli::cli_abort(c(
+      "The variable name passed to {.arg source_var} does not exist in the data.",
+      "i" = "Column {.val {refQ}} was not found."
+    ))
   }
 
   if (newQ %in% names(.data)){
-    warning("The variable name passed to the 'new_var' argument already exists in the data. It will be overwritten.")
+    cli::cli_warn("The variable name passed to {.arg new_var} already exists in the data. It will be overwritten.")
   }
 
   if (!is.integer(n)){
-    stop("The 'n' argument must be an integer. Include an 'L' suffix to specify an integer value - e.x. 4L.")
+    cli::cli_abort(c(
+      "The {.arg n} argument must be an integer.",
+      "i" = "Include an {.code L} suffix to specify an integer value, e.g. {.code 4L}."
+    ))
   }
 
   if (n < 2L){
-    stop("The 'n' argument must be 2L or greater.")
+    cli::cli_abort("The {.arg n} argument must be {.code 2L} or greater.")
   }
 
   if (!return %in% c("label", "factor")){
-    stop("The 'return' argument must be either 'label' or 'factor'.")
+    cli::cli_abort(c(
+      "The {.arg return} argument must be either {.val label} or {.val factor}.",
+      "i" = "Got {.val {return}}."
+    ))
   }
 
   ## calculate breaks

--- a/R/dep_rank.R
+++ b/R/dep_rank.R
@@ -30,13 +30,16 @@ dep_percentiles <- function(.data, source_var, new_var){
 
   # check inputs
   if (!inherits(.data, what = "data.frame")){
-    stop("The '.data' object provided is not a data frame or sf object.")
+    cli::cli_abort("The {.arg .data} object provided is not a data frame or sf object.")
   }
 
   source_varQN <- as.character(substitute(source_var))
 
   if (source_varQN %in% names(.data) == FALSE){
-    stop("The given 'source_var' column is not found in your data object.")
+    cli::cli_abort(c(
+      "The given {.arg source_var} column is not found in your data object.",
+      "i" = "Column {.val {source_varQN}} does not exist."
+    ))
   }
 
   # if (!inherits(.data[[source_varQN]], what = "numeric")){
@@ -49,7 +52,7 @@ dep_percentiles <- function(.data, source_var, new_var){
     new_varQN <- as.character(substitute(new_var))
 
     if (new_varQN %in% names(.data) == TRUE){
-      warning("The given 'new_var' column exists in your data and will be overwritten.")
+      cli::cli_warn("The given {.arg new_var} column exists in your data and will be overwritten.")
     }
   }
 

--- a/R/dep_sample_data.R
+++ b/R/dep_sample_data.R
@@ -24,11 +24,17 @@ dep_sample_data <- function(index){
 
   # check inputs
   if (missing(index) == TRUE){
-    stop("A 'index' value must be provided. Please choose one of: 'adi', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "A {.arg index} value must be provided.",
+      "i" = "Choose one of: {.val adi}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   if (all(index %in% c("adi", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE){
-    stop("Invalid index provided. Please choose one of: 'adi', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+    cli::cli_abort(c(
+      "Invalid {.arg index} provided: {.val {index}}.",
+      "i" = "Choose one of: {.val adi}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
+    ))
   }
 
   # get vector of variables

--- a/R/dep_utils.R
+++ b/R/dep_utils.R
@@ -41,13 +41,10 @@ validate_state <- function(state, .msg=interactive()) {
       # but warn the caller
       state_sub <- substr(state, 1, 2)
       if (state_sub %in% states_lookup$fips) {
-        message(sprintf("Using first two digits of %s - '%s' (%s) - for FIPS code.",
-                        state, state_sub,
-                        states_lookup[states_lookup$fips == state_sub, "name"]),
-                call.=FALSE)
+        cli::cli_inform("Using first two digits of {state} - {.val {state_sub}} ({states_lookup[states_lookup$fips == state_sub, 'name']}) - for FIPS code.")
         return(state_sub)
       } else {
-        warning(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
+        cli::cli_warn("{.val {state}} is not a valid FIPS code or state name/abbreviation.")
         return(NULL)
       }
     }
@@ -57,26 +54,22 @@ validate_state <- function(state, .msg=interactive()) {
     if (nchar(state) == 2 & state %in% states_lookup$abb) { # yay, an abbrev!
 
       if (.msg)
-        message(sprintf("Using FIPS code '%s' for state '%s'",
-                        states_lookup[states_lookup$abb == state, "fips"],
-                        toupper(state)))
+        cli::cli_inform("Using FIPS code {.val {states_lookup[states_lookup$abb == state, 'fips']}} for state {.val {toupper(state)}}.")
       return(states_lookup[states_lookup$abb == state, "fips"])
 
     } else if (nchar(state) > 2 & state %in% states_lookup$name) { # yay, a name!
 
       if (.msg)
-        message(sprintf("Using FIPS code '%s' for state '%s'",
-                        states_lookup[states_lookup$name == state, "fips"],
-                        simpleCapSO(state)))
+        cli::cli_inform("Using FIPS code {.val {states_lookup[states_lookup$name == state, 'fips']}} for state {.val {simpleCapSO(state)}}.")
       return(states_lookup[states_lookup$name == state, "fips"])
 
     } else {
-      warning(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
+      cli::cli_warn("{.val {state}} is not a valid FIPS code or state name/abbreviation.")
       return(NULL)
     }
 
   } else {
-    warning(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
+    cli::cli_warn("{.val {state}} is not a valid FIPS code or state name/abbreviation.")
     return(NULL)
   }
 

--- a/tests/testthat/test_dep_build_varlist.R
+++ b/tests/testthat/test_dep_build_varlist.R
@@ -3,25 +3,25 @@
 
 test_that("incorrectly specified parameters trigger appropriate errors", {
   expect_error(dep_build_varlist(index = "svi20", year = 2020, survey = "acs5", output = "vector"),
-               "A level of geography must be provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+               "geography.*must be provided")
   expect_error(dep_build_varlist(geography = "ham", index = "svi20", year = 2020, survey = "acs5", output = "vector"),
-               "Invalid level of geography provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+               "Invalid.*geography")
   expect_error(dep_build_varlist(geography = "tract", year = 2020, survey = "acs5", output = "vector"),
-               "A 'index' value must be provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+               "index.*must be provided")
   expect_error(dep_build_varlist(geography = "tract", index = "ham", year = 2020, survey = "acs5", output = "vector"),
-               "Invalid index provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+               "Invalid.*index")
   expect_error(dep_build_varlist(geography = "tract", index = "svi20", year = 2000, survey = "acs5", output = "vector"),
-               "The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+               "Invalid.*year")
   expect_error(dep_build_varlist(geography = "tract", index = "svi20", year = "ham", survey = "acs5", output = "vector"),
-               "The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+               "Invalid.*year")
   expect_error(dep_build_varlist(geography = "tract", index = "svi20", year = 2020, survey = "acs3", output = "vector"),
-               "The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+               "acs3.*after.*2013")
   expect_error(dep_build_varlist(geography = "tract", index = "svi20", year = 2020, survey = "acs3", output = "vector"),
-               "The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+               "acs3.*after.*2013")
   expect_error(dep_build_varlist(geography = "tract", index = "svi20", year = 2020, survey = "ham", output = "vector"),
-               "The 'survey' value provided is not valid. Please choose one of 'acs1', 'acs3', or 'acs5'.")
+               "Invalid.*survey")
   expect_error(dep_build_varlist(geography = "tract", index = "svi20", year = 2020, survey = "acs5", output = "ham"),
-               "The 'output' value provided is not valid. Please choose one of 'vector' or 'tibble'.")
+               "Invalid.*output")
 })
 
 # test adi output ------------------------------------------------

--- a/tests/testthat/test_dep_calc_index.R
+++ b/tests/testthat/test_dep_calc_index.R
@@ -8,34 +8,34 @@ test_that("incorrectly specified parameters trigger appropriate errors", {
 
   expect_error(dep_calc_index(sample_df, index = "ndi_m", year = 2022,
                               survey = "acs5", output = "wide"),
-               "A level of geography must be provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+               "geography.*must be provided")
   expect_error(dep_calc_index(sample_df, geography = "ham", index = "ndi_m",
                               year = 2022, survey = "acs5", output = "wide"),
-               "Invalid level of geography provided. Please choose one of: 'county', 'zcta3', 'zcta5', or 'tract'.")
+               "Invalid.*geography")
   expect_error(dep_calc_index(sample_df, geography = "county", year = 2022,
                               survey = "acs5", output = "wide"),
-               "A 'index' value must be provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+               "index.*must be provided")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ham",
                               year = 2022, survey = "acs5", output = "wide"),
-               "Invalid index provided. Please choose one of: 'adi', 'gini', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+               "Invalid.*index")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ndi_m",
                               year = 2000, survey = "acs5", output = "wide"),
-               "The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+               "year.*invalid")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ndi_m",
                               year = "ham", survey = "acs5", output = "wide"),
-               "The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
+               "year.*invalid")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ndi_m",
                               year = 2022, survey = "acs3", output = "wide"),
-               "The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+               "acs3.*discontinued")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ndi_m",
                               year = 2022, survey = "acs3", output = "wide"),
-               "The 'acs3' survey was discontinued after 2013. Please select one of 'acs1' or 'acs5'.")
+               "acs3.*discontinued")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ndi_m",
                               year = 2022, survey = "ham", output = "wide"),
-               "The 'survey' value provided is not valid. Please choose one of 'acs1', 'acs3', or 'acs5'.")
+               "survey.*not valid")
   expect_error(dep_calc_index(sample_df, geography = "county", index = "ndi_m",
                               year = 2022, survey = "acs5", output = "ham"),
-               "The 'output' value provided is not valid. Please choose one of 'wide' or 'tidy'.")
+               "output.*not valid")
 })
 
 # test errors ------------------------------------------------

--- a/tests/testthat/test_dep_get_index.R
+++ b/tests/testthat/test_dep_get_index.R
@@ -4,7 +4,7 @@
 test_that("missing geography triggers error", {
   expect_error(
     dep_get_index(index = "ndi_m", year = 2020, survey = "acs5"),
-    "A level of geography must be provided"
+    "geography.*must be provided"
   )
 })
 
@@ -12,39 +12,39 @@ test_that("invalid geography triggers error", {
 
   expect_error(
     dep_get_index(geography = "hamlet", index = "ndi_m", year = 2020, survey = "acs5"),
-    "Invalid level of geography provided"
+    "Invalid.*geography"
   )
 })
 
 test_that("missing index triggers error", {
   expect_error(
     dep_get_index(geography = "county", year = 2020, survey = "acs5"),
-    "A 'index' value must be provided"
+    "index.*must be provided"
   )
 })
 
 test_that("invalid index triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ham", year = 2020, survey = "acs5"),
-    "Invalid index provided"
+    "Invalid.*index"
   )
 })
 
 test_that("missing year triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", survey = "acs5"),
-    "A 'year' value must be provided"
+    "year.*must be provided"
   )
 })
 
 test_that("invalid year triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2000, survey = "acs5"),
-    "The 'year' value provided is invalid"
+    "year.*invalid"
   )
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = "ham", survey = "acs5"),
-    "The 'year' value provided is invalid"
+    "year.*invalid"
   )
 })
 
@@ -69,14 +69,14 @@ test_that("svi20s year constraint triggers error", {
 test_that("invalid survey triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "ham"),
-    "The 'survey' value provided is not valid"
+    "survey.*not valid"
   )
 })
 
 test_that("discontinued acs3 survey triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs3"),
-    "The 'acs3' survey was discontinued after 2013"
+    "acs3.*discontinued"
   )
 })
 
@@ -84,7 +84,7 @@ test_that("non-logical return_percentiles triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   return_percentiles = "yes"),
-    "Please provide a logical scalar for 'return_percentiles'"
+    "logical scalar.*return_percentiles"
   )
 })
 
@@ -92,7 +92,7 @@ test_that("non-logical keep_subscales triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   keep_subscales = "yes"),
-    "Please provide a logical scalar for 'keep_subscales'"
+    "logical scalar.*keep_subscales"
   )
 })
 
@@ -100,7 +100,7 @@ test_that("non-logical keep_components triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   keep_components = "yes"),
-    "Please provide a logical scalar for 'keep_components'"
+    "logical scalar.*keep_components"
   )
 })
 
@@ -116,7 +116,7 @@ test_that("state and county both specified triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   state = "MO", county = "29510"),
-    "Please choose values for either 'state' or 'county' but not both"
+    "state.*or.*county.*not both"
   )
 })
 
@@ -124,7 +124,7 @@ test_that("non-logical puerto_rico triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   puerto_rico = "yes"),
-    "Please provide a logical scalar for 'puerto_rico'"
+    "logical scalar.*puerto_rico"
   )
 })
 
@@ -132,7 +132,7 @@ test_that("invalid output triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   output = "ham"),
-    "The 'output' requested is invalid"
+    "output.*invalid"
   )
 })
 
@@ -140,7 +140,7 @@ test_that("tidy output with keep_components triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   output = "tidy", keep_components = TRUE),
-    "Tidy output is only available if 'keep_components' is 'FALSE'"
+    "Tidy output.*keep_components.*FALSE"
   )
 })
 
@@ -148,7 +148,7 @@ test_that("non-logical zcta_cb triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   zcta_cb = "yes"),
-    "Please provide a logical scalar for 'zcta_cb'"
+    "logical scalar.*zcta_cb"
   )
 })
 
@@ -156,6 +156,6 @@ test_that("non-logical shift_geo triggers error", {
   expect_error(
     dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5",
                   shift_geo = "yes"),
-    "Please provide a logical scalar for 'shift_geo'"
+    "logical scalar.*shift_geo"
   )
 })

--- a/tests/testthat/test_dep_map_breaks.R
+++ b/tests/testthat/test_dep_map_breaks.R
@@ -13,7 +13,7 @@ test_that("invalid return argument triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
                    style = "fisher", return = "ham"),
-    "The 'return' argument only accepts 'col' or 'breaks' as arguments."
+    "return.*only accepts.*col.*breaks"
   )
 })
 
@@ -22,7 +22,7 @@ test_that("supplying breaks and return = 'breaks' triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks",
                    breaks = c(0, 25, 50, 75, 100), return = "breaks"),
-    "Returning breaks is only possible if breaks are not first supplied."
+    "Returning breaks.*only possible.*breaks"
   )
 })
 
@@ -30,15 +30,15 @@ test_that("missing both classes/style and breaks triggers error", {
   df <- test_data()
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks"),
-    "Values must be supplied for both 'classes' and 'style', or 'breaks'."
+    "classes.*style.*breaks"
   )
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5),
-    "Values must be supplied for both 'classes' and 'style', or 'breaks'."
+    "classes.*style.*breaks"
   )
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", style = "fisher"),
-    "Values must be supplied for both 'classes' and 'style', or 'breaks'."
+    "classes.*style.*breaks"
   )
 })
 
@@ -46,7 +46,7 @@ test_that("missing new_var with return = 'col' triggers error", {
   df <- test_data()
   expect_error(
     dep_map_breaks(df, var = "NDI_M", classes = 5, style = "fisher"),
-    "A variable name for a new column must be supplied if 'return' is 'col'."
+    "new_var.*return.*col"
   )
 })
 
@@ -55,7 +55,7 @@ test_that("nonexistent source variable triggers error", {
   expect_error(
     dep_map_breaks(df, var = "FAKE_VAR", new_var = "breaks", classes = 5,
                    style = "fisher"),
-    "The variable supplied for 'var' cannot be found in the data object."
+    "var.*cannot be found"
   )
 })
 
@@ -64,7 +64,7 @@ test_that("non-numeric source variable triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NAME", new_var = "breaks", classes = 5,
                    style = "fisher"),
-    "The variable supplied for 'var' is not formatted as a numeric or integer variable."
+    "var.*numeric.*integer"
   )
 })
 
@@ -73,7 +73,7 @@ test_that("non-numeric classes triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = "five",
                    style = "fisher"),
-    "The value supplied for 'classes' is not formatted as a numeric or integer value."
+    "classes.*numeric.*integer"
   )
 })
 
@@ -82,7 +82,7 @@ test_that("invalid style triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
                    style = "invalid_style"),
-    "The style provided is not supported"
+    "style.*not supported"
   )
 })
 
@@ -91,7 +91,7 @@ test_that("non-numeric breaks triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks",
                    breaks = c("a", "b", "c")),
-    "The vector supplied for 'breaks' is not formatted as a numeric or integer vector."
+    "breaks.*numeric.*integer"
   )
 })
 
@@ -99,7 +99,7 @@ test_that("too few breaks triggers error", {
   df <- test_data()
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", breaks = c(0, 100)),
-    "At least three values must be supplied"
+    "At least three values.*breaks"
   )
 })
 
@@ -108,7 +108,7 @@ test_that("non-numeric sig_digits triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
                    style = "fisher", sig_digits = "two"),
-    "The value supplied for 'sig_digits' is not formatted as a numeric or integer value."
+    "sig_digits.*numeric.*integer"
   )
 })
 
@@ -117,7 +117,7 @@ test_that("non-logical show_warnings triggers error", {
   expect_error(
     dep_map_breaks(df, var = "NDI_M", new_var = "breaks", classes = 5,
                    style = "fisher", show_warnings = "yes"),
-    "The value supplied for 'show_warnings' is not valid"
+    "show_warnings.*logical"
   )
 })
 

--- a/tests/testthat/test_dep_percentiles.R
+++ b/tests/testthat/test_dep_percentiles.R
@@ -10,7 +10,7 @@ test_data <- function() {
 test_that("non-data-frame .data triggers error", {
   expect_error(
     dep_percentiles(.data = "not a data frame", source_var = x, new_var = y),
-    "The '.data' object provided is not a data frame"
+    ".data.*not a data frame"
   )
 })
 
@@ -18,7 +18,7 @@ test_that("nonexistent source_var triggers error", {
   df <- test_data()
   expect_error(
     dep_percentiles(df, source_var = FAKE_VAR, new_var = pctile),
-    "The given 'source_var' column is not found in your data object."
+    "source_var.*not found"
   )
 })
 
@@ -50,7 +50,7 @@ test_that("existing new_var produces a warning", {
   df <- test_data()
   expect_warning(
     dep_percentiles(df, source_var = B06009_001E, new_var = GEOID),
-    "The given 'new_var' column exists in your data and will be overwritten."
+    "new_var.*exists.*overwritten"
   )
 })
 

--- a/tests/testthat/test_dep_quantiles.R
+++ b/tests/testthat/test_dep_quantiles.R
@@ -12,7 +12,7 @@ test_data <- function() {
 test_that("non-data-frame .data triggers error", {
   expect_error(
     dep_quantiles(.data = "not a data frame", source_var = "x", new_var = "y"),
-    "The object passed to the '.data' argument must be a data frame."
+    "object.*\\.data.*must be a data frame"
   )
 })
 
@@ -20,7 +20,7 @@ test_that("nonexistent source_var triggers error", {
   df <- test_data()
   expect_error(
     dep_quantiles(df, source_var = "FAKE_VAR", new_var = "q"),
-    "The variable name passed to the 'source_var' argument does not exist"
+    "source_var.*does not exist"
   )
 })
 
@@ -28,7 +28,7 @@ test_that("non-integer n triggers error", {
   df <- test_data()
   expect_error(
     dep_quantiles(df, source_var = NDI_M, new_var = q, n = 4),
-    "The 'n' argument must be an integer"
+    "n.*must be an integer"
   )
 })
 
@@ -36,7 +36,7 @@ test_that("n < 2L triggers error", {
   df <- test_data()
   expect_error(
     dep_quantiles(df, source_var = NDI_M, new_var = q, n = 1L),
-    "The 'n' argument must be 2L or greater"
+    "n.*must be.*2L.*or greater"
   )
 })
 
@@ -44,7 +44,7 @@ test_that("invalid return triggers error", {
   df <- test_data()
   expect_error(
     dep_quantiles(df, source_var = NDI_M, new_var = q, return = "ham"),
-    "The 'return' argument must be either 'label' or 'factor'"
+    "return.*must be.*label.*or.*factor"
   )
 })
 

--- a/tests/testthat/test_dep_sample_data.R
+++ b/tests/testthat/test_dep_sample_data.R
@@ -3,9 +3,9 @@
 
 test_that("incorrectly specified parameters trigger appropriate errors", {
   expect_error(dep_sample_data(),
-               "A 'index' value must be provided. Please choose one of: 'adi', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+               "index.*value must be provided")
   expect_error(dep_sample_data(index = "ham"),
-               "Invalid index provided. Please choose one of: 'adi', 'ndi_m', 'ndi_pw', 'svi10', 'svi14', 'svi20', or 'svi20s'.")
+               "Invalid.*index.*provided")
 })
 
 # test adi output ------------------------------------------------

--- a/tests/testthat/test_dep_utils.R
+++ b/tests/testthat/test_dep_utils.R
@@ -50,7 +50,7 @@ test_that("validate_state handles valid abbreviations", {
 test_that("validate_state returns NULL for invalid input", {
   expect_warning(
     result <- deprivateR:::validate_state("ZZ", .msg = FALSE),
-    "is not a valid FIPS code"
+    "not a valid FIPS code"
   )
   expect_null(result)
 })


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Migrates all base R messaging functions (`stop()`, `warning()`, `message()`) to their cli package equivalents (`cli::cli_abort()`, `cli::cli_warn()`, `cli::cli_inform()`) across the entire package. This provides tidyverse-style formatted error messages with backtick-quoted argument names and structured bullet points.

## Implementation

- Added `cli` to Imports in DESCRIPTION
- Converted 74 `stop()` → `cli::cli_abort()` across 8 files
- Converted 7 `warning()` → `cli::cli_warn()` across 4 files
- Converted 3 `message()` → `cli::cli_inform()` in `dep_utils.R`
- Updated all 8 test files to use regex pattern matching (cli formats arg names with backticks, breaking exact-match assertions)
- No logic changes — purely a messaging refactor

## Testing

- All 179 tests pass, 0 failures, 1 intentional skip (pre-existing territory validation bug)
- R CMD check passes locally
- Test patterns use short regex anchors for resilience against future message wording tweaks

## Closes

- Closes #28

## Notes

- `cli::cli_abort()` wraps `rlang::abort()` — errors are now classed conditions (`rlang_error`) rather than plain `simpleError`
- `cli::cli_warn()` wraps `rlang::warn()`, `cli::cli_inform()` wraps `rlang::inform()`
- R/ source code changes flagged for UAT and approved by maintainer prior to PR creation
<!-- pr-skill-managed-end -->
