### PR TITLE
docs: populate project documentation with substantive content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Introductory "Getting Started" vignette covering all supported indices, sample data workflow, `dep_get_index()` one-step workflow, quantiles, map breaks, and spatial output (#6)
+- Substantive content for `docs/ARCHITECTURE.md`, `docs/GLOSSARY.md`, `docs/OBJECTIVES.md`, and `docs/decisions/` (#19)
 - Unit tests for `dep_get_index`, `dep_map_breaks`, `dep_quantiles`, `dep_percentiles`, and internal helpers — 179 assertions across 8 test files (#3)
 - testthat 3rd edition adopted (`Config/testthat/edition: 3` in DESCRIPTION) (#4)
 - lintr CI workflow with `.lintr` config; currently enforces `linters_with_defaults()` minus style-only linters that conflict with existing code (#12)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,94 @@
+---
+last_updated: 2026-05-28
+last_updated_by: github-copilot-cli
+owner_skill: architecture_overview/SKILL.md
+quadrant: explanation
+---
+
 # Architecture
 
-<!-- Seeded by EVGen bootstrap. Customize for deprivateR. -->
+## Overview
+
+`deprivateR` is an R package that provides a unified interface for calculating area-level deprivation indices from U.S. Census Bureau data. It wraps multiple upstream packages (`sociome`, `ndi`, `tidycensus`) behind a consistent API, adds CDC Social Vulnerability Index (SVI) calculations natively, and provides post-processing utilities for analysis and visualization.
+
+## Package Structure
+
+```
+R/
+  dep_get_index.R        # Primary user entry point (download + calculate)
+  dep_calc_index.R       # Calculate indices on existing data
+  dep_build_varlist.R    # Census variable list construction
+  dep_get_data.R         # Census data download (internal)
+  dep_process.R          # Orchestrator for index-specific processors
+  dep_process_adi.R      # ADI calculation (delegates to sociome)
+  dep_process_gini.R     # Gini coefficient (delegates to tidycensus)
+  dep_process_ndi.R      # NDI Messer + Powell-Wiley (delegates to ndi)
+  dep_process_svi.R      # SVI calculation (native implementation)
+  dep_quantiles.R        # Quantile binning utility
+  dep_rank.R             # Percentile ranking utility
+  dep_map_breaks.R       # Choropleth classification breaks
+  dep_sample_data.R      # Bundled sample data accessor
+  dep_utils.R            # Shared internal helpers
+  dep_globals.R          # NSE global variable declarations
+  sysdata.rda            # Internal data (see below)
+```
+
+## Data Flow
+
+The package supports two primary workflows:
+
+### One-Step (dep_get_index)
+
+```
+User call
+  -> dep_get_index()
+    -> dep_build_varlist()     [determine which Census variables are needed]
+    -> dep_get_data()          [download via tidycensus]
+    -> dep_process()           [route to index-specific processor]
+      -> dep_process_svi()     [or _adi, _gini, _ndi_m, _ndi_pw]
+    -> output formatting       [wide, tidy, or sf]
+  <- tibble or sf object
+```
+
+### Two-Step (dep_calc_index)
+
+```
+User provides pre-downloaded data
+  -> dep_calc_index()
+    -> dep_process()           [route to index-specific processor]
+    -> output formatting       [wide or tidy only]
+  <- tibble
+```
+
+## Key Design Decisions
+
+- **Variable lists are year-sensitive.** Census variable codes change between ACS releases. The `request_vars` internal dataset maps `(index, year, survey)` tuples to the correct variable codes.
+- **SVI is computed natively.** Unlike ADI and NDI (which delegate to `sociome` and `ndi`), SVI calculations are implemented directly in `deprivateR` to support four methodology variants (2010, 2014, 2020, 2020-simplified).
+- **Geography abstraction.** ZCTA3 and ZCTA5 geographies require special handling (aggregation, crosswalks) that is encapsulated in `dep_get_zcta3()` and `dep_get_zcta5()`.
+- **Sample data for offline use.** Missouri county-level 2022 ACS data is bundled in `sysdata.rda` so tests and vignettes run without API keys.
+
+## Internal Data (sysdata.rda)
+
+| Object | Description |
+|--------|-------------|
+| `mo` | Missouri county-level ACS data (2022) for sample data functions |
+| `request_vars` | Lookup table mapping (index, year, survey, geography) to Census variable codes |
+| `states_lookup` | State FIPS code and abbreviation crosswalk |
+
+## Exported Functions
+
+| Function | Role |
+|----------|------|
+| `dep_get_index()` | Download + calculate (primary entry point) |
+| `dep_calc_index()` | Calculate on existing data |
+| `dep_build_varlist()` | Get required Census variable names |
+| `dep_sample_data()` | Access bundled sample datasets |
+| `dep_quantiles()` | Bin scores into quantile categories |
+| `dep_percentiles()` | Calculate percentile ranks |
+| `dep_map_breaks()` | Classification breaks for choropleth maps |
+
+## Dependencies
+
+**Core:** `tidycensus` (Census API), `sociome` (ADI), `ndi` (NDI), `sf` (spatial), `dplyr`/`tidyr`/`tibble` (data manipulation), `classInt` (map breaks), `cli` (user messaging).
+
+**Suggested:** `knitr`/`rmarkdown` (vignettes), `testthat` (testing), `lintr` (style), `spelling` (documentation QC), `tigris` (shapefiles).

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,3 +1,51 @@
+---
+last_updated: 2026-05-28
+last_updated_by: github-copilot-cli
+owner_skill: glossary/SKILL.md
+quadrant: reference
+---
+
 # Glossary
 
-<!-- Seeded by EVGen bootstrap. Customize for deprivateR. -->
+Domain terms used across `deprivateR` documentation, code, and issues.
+
+## Deprivation Indices
+
+| Term | Definition | Source |
+|------|-----------|--------|
+| **ADI** | Area Deprivation Index. A factor-based composite of 17 socioeconomic indicators measuring neighborhood disadvantage. | [Singh (2003)](https://doi.org/10.2105/AJPH.93.7.1137) |
+| **Gini Coefficient** | A measure of income inequality ranging from 0 (perfect equality) to 1 (perfect inequality). | U.S. Census Bureau ACS Table B19083 |
+| **NDI (Messer)** | Neighborhood Deprivation Index per Messer et al. A principal-component-based composite of 8 census variables. Higher values indicate greater deprivation. | [Messer et al. (2006)](https://doi.org/10.1007/s10900-006-9002-y) |
+| **NDI (Powell-Wiley)** | Neighborhood Deprivation Index per Powell-Wiley et al. An alternative NDI formulation using a different variable set and weighting. | [Andrews et al. (2020)](https://doi.org/10.1080/17445647.2020.1750066) |
+| **SVI** | Social Vulnerability Index. The CDC/ATSDR composite measure of community vulnerability to health hazards, calculated as percentile ranks across four themes. | [CDC/ATSDR SVI](https://www.atsdr.cdc.gov/placeandhealth/svi/) |
+| **SVI Themes** | The four SVI sub-domains: Socioeconomic Status (SES), Household Characteristics and Disability (HCD), Minority Status and Language (MSL), and Housing Type and Transportation (HTT). | CDC/ATSDR |
+
+## Census and Geography
+
+| Term | Definition |
+|------|-----------|
+| **ACS** | American Community Survey. The U.S. Census Bureau's ongoing annual survey providing demographic, social, economic, and housing estimates. Available as 1-year, 3-year (discontinued after 2013), or 5-year products. |
+| **FIPS** | Federal Information Processing Standards code. Numeric codes identifying states (2-digit) and counties (5-digit) in the U.S. |
+| **GEOID** | Geographic Identifier. A standardized code uniquely identifying a census geographic unit (e.g., state + county + tract FIPS concatenation). |
+| **ZCTA** | ZIP Code Tabulation Area. Census-defined approximations of USPS ZIP Code service areas. ZCTA5 uses 5-digit codes; ZCTA3 aggregates to 3-digit prefixes. |
+| **Census Tract** | A small, relatively stable geographic area defined by the Census Bureau, typically containing 1,200 to 8,000 people. The most common unit for neighborhood-level deprivation analysis. |
+
+## Package Concepts
+
+| Term | Definition |
+|------|-----------|
+| **Choropleth** | A thematic map where areas are shaded proportionally to a measured variable. `dep_map_breaks()` creates classification bins for this purpose. |
+| **Subscales** | Sub-components of a composite index (e.g., SVI themes, ADI factor groupings). Retained when `keep_subscales = TRUE`. |
+| **Components** | The individual Census demographic variables that feed into an index calculation. Retained when `keep_components = TRUE`. |
+| **Percentile rank** | A value's position in a distribution expressed as a percentage (0-100). SVI is always returned as percentile ranks; other indices use raw scores by default. |
+| **Quantile** | A division of a distribution into equal-probability groups (quartiles = 4, quintiles = 5, deciles = 10). Used to convert continuous deprivation scores into categorical variables for modeling. |
+
+## R Ecosystem
+
+| Term | Definition |
+|------|-----------|
+| **tidycensus** | R package providing an interface to the Census Bureau API. Used by `deprivateR` for data download and Gini coefficient retrieval. |
+| **sociome** | R package implementing ADI calculations. Wrapped by `dep_process_adi()`. |
+| **ndi** | R package implementing NDI (Messer and Powell-Wiley). Wrapped by `dep_process_ndi_m()` and `dep_process_ndi_pw()`. |
+| **classInt** | R package providing classification interval algorithms (Fisher-Jenks, quantile, equal, etc.). Used by `dep_map_breaks()`. |
+| **sf** | Simple Features for R. The standard package for spatial vector data. Used when `output = "sf"` is requested. |

--- a/docs/OBJECTIVES.md
+++ b/docs/OBJECTIVES.md
@@ -1,3 +1,54 @@
+---
+last_updated: 2026-05-28
+last_updated_by: github-copilot-cli
+owner_skill: objectives/SKILL.md
+quadrant: governance
+---
+
 # Objectives
 
-<!-- Seeded by EVGen bootstrap. Customize for deprivateR. -->
+## Active
+
+### O1: Maintain deprivateR as an in-production CRAN package
+
+**Why:** The package is live on CRAN and needs ongoing maintenance, documentation, and quality investment to remain viable and useful.
+
+**Key Results:**
+
+| KR | Target | Current | Last check-in |
+|----|--------|---------|---------------|
+| KR1.1 | Introductory vignette published on pkgdown site | Done | 2026-05-28 |
+| KR1.2 | All docs/ files contain substantive content | In progress (#19) | 2026-05-28 |
+| KR1.3 | Zero open priority:high bugs | 1 open (#35 pkgdown CI) | 2026-05-28 |
+
+**Supporting epics:**
+- [Epic C] Documentation and User Onboarding (#17)
+
+**Completed epics:**
+- [Epic A] CRAN Compliance and Release Readiness (#15) - closed 2026-05-27
+- [Epic B] Test Quality and Developer Experience (#16) - closed 2026-05-28
+
+---
+
+### O2: Deliver v0.2.0 feature additions
+
+**Why:** Expand the package's analytical coverage with new indices and improve the developer experience for API key management.
+
+**Key Results:**
+
+| KR | Target | Current | Last check-in |
+|----|--------|---------|---------------|
+| KR2.1 | Theil's H index available as a new index type | Not started (#10) | 2026-05-28 |
+| KR2.2 | Census API key wrapper with interactive prompts shipped | Not started (#11) | 2026-05-28 |
+| KR2.3 | Both new features have tests and documentation | Not started | 2026-05-28 |
+
+**Supporting epics:**
+- [Epic D] New Features v0.2.0 (#18)
+
+## Completed
+
+_None yet._
+
+## Parked
+
+_None._

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,3 +1,21 @@
-# Readme
+---
+last_updated: 2026-05-28
+last_updated_by: github-copilot-cli
+quadrant: history
+---
 
-<!-- Seeded by EVGen bootstrap. Customize for deprivateR. -->
+# Local Architecture Decision Records
+
+This directory holds **repo-specific ADRs** for decisions unique to `deprivateR`. For **workflow-intrinsic ADRs** (shared across all EVGen repos), see [`.github/vendored-decisions/README.md`](../../.github/vendored-decisions/README.md).
+
+## Conventions
+
+- Filenames: `ADR-NNNN-kebab-case-title.md`
+- Numbering starts at 0001, monotonic, never reused
+- ADRs are immutable once accepted; supersede via a new ADR
+- Template: [`_template.md`](./_template.md)
+- Filing tool: [`adr/SKILL.md`](../../.github/skills/adr/SKILL.md)
+
+## Index
+
+_No local ADRs filed yet. Decisions so far have been captured in vendored ADRs (workflow-level) or inline in issue/PR discussions._

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,3 +1,23 @@
-#  Template
+---
+status: proposed
+date: YYYY-MM-DD
+decision_makers: []
+---
 
-<!-- Seeded by EVGen bootstrap. Customize for deprivateR. -->
+# ADR-NNNN: Title
+
+## Context
+
+What is the issue that we are seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we are proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+## Alternatives Considered
+
+What other options were evaluated and why were they rejected?


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Populates all placeholder docs/ files with substantive content, completing the last sub-issue of Epic C (Documentation & User Onboarding).

## Implementation

- **ARCHITECTURE.md**: Package structure tree, two data-flow diagrams (one-step and two-step workflows), key design decisions (year-sensitive variables, native SVI, geography abstraction, sample data), internal data table, exported function summary
- **GLOSSARY.md**: 20+ terms organized into four sections (Deprivation Indices, Census and Geography, Package Concepts, R Ecosystem) with source links
- **OBJECTIVES.md**: Two active objectives (O1: maintain in-production CRAN package, O2: deliver v0.2.0 features) with measurable KRs tied to open epics
- **decisions/README.md**: Explains local vs vendored ADR directory separation, links to vendored index, includes empty local index
- **decisions/_template.md**: Full ADR template (Context, Decision, Consequences, Alternatives)

## Testing

- Documentation-only change; no code modified
- All cross-references between docs verified valid

## Closes

- Closes #19

## Notes

- This completes Epic C (#17) - all 3 sub-issues now closed (#6, #13, #19)
- CHANGELOG entry added under [Unreleased] > Added
<!-- pr-skill-managed-end -->
