### PR TITLE
fix: resolve pkgdown CI build failure from docs/ directory conflict

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,3 +30,4 @@
 ^\.lintr$
 ^\.positai$
 ^\.claude$
+^_site$

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           clean: false
           branch: gh-pages
-          folder: docs
+          folder: _site

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ vignettes/*.pdf
 docs/WORKFLOW.md
 docs/README.md
 .positai
+
+# pkgdown output
+_site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- pkgdown CI build failure caused by `docs/` directory conflict — pkgdown now outputs to `_site/` (#35)
+
 ### Changed
 
 - Migrated all `stop()`/`warning()`/`message()` calls to `cli::cli_abort()`/`cli::cli_warn()`/`cli::cli_inform()` for tidyverse-style formatted error messages (#28)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,5 @@
 url: https://pfizer-opensource.github.io/deprivateR/
+destination: _site
 
 reference:
   - title: "Core Functionality"


### PR DESCRIPTION
## Summary

Resolves the pkgdown CI build failure caused by `docs/` containing project governance documentation (ARCHITECTURE.md, GLOSSARY.md, ROADMAP.md, etc.) that conflicts with pkgdown's expectation of exclusive directory ownership.

## Implementation

Configures pkgdown to output to `_site/` instead of the default `docs/`:
- `_pkgdown.yml`: added `destination: _site`
- `.github/workflows/pkgdown.yml`: deploy from `_site/` instead of `docs/`
- `.gitignore`: added `_site/`
- `.Rbuildignore`: added `^_site$`

## Testing

- Verified pkgdown workflow YAML is syntactically valid
- Confirmed `docs/` governance files are untouched
- `_site/` is properly gitignored and excluded from R package builds

## Closes

- Closes #35

## Notes

Chose `destination: _site` over moving governance docs because it requires fewer cross-reference updates and keeps `docs/` as the conventional home for project documentation.
