### PR TITLE
docs: remove manual @usage tags from roxygen2 documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Removed manual `@usage` roxygen2 tags from function documentation; usage is now auto-generated from signatures (#40)
 - Migrated all `stop()`/`warning()`/`message()` calls to `cli::cli_abort()`/`cli::cli_warn()`/`cli::cli_inform()` for tidyverse-style formatted error messages (#28)
 - Bumped minimum R version from 4.1 to 4.4 (required by Matrix package dependency chain)
 - Bumped minimum R version from 3.5 to 4.1 (#5)

--- a/R/dep_build_varlist.R
+++ b/R/dep_build_varlist.R
@@ -3,7 +3,6 @@
 #' @description This function creates a vector or \code{tibble} containing
 #'     variables included in particular calls.
 #'
-#' @usage dep_build_varlist(geography, index, year, survey = "acs5", output = "vector")
 #'
 #' @param geography A character scalar; one of \code{"state"}, \code{"county"}, or
 #'     \code{"tract"}

--- a/R/dep_calc_index.R
+++ b/R/dep_calc_index.R
@@ -6,9 +6,6 @@
 #'     more information. For information about structuring your data prior to
 #'     using this function, see Details below.
 #'
-#' @usage dep_calc_index(.data, geography, index, year, survey = "acs5",
-#'     return_percentiles = FALSE, keep_subscales = FALSE, keep_components = FALSE,
-#'     output = "wide")
 #'
 #' @param .data A data frame, tibble, or \code{sf} object that contains all
 #'     of the columns needed to calculate your selected deprivation measure(s).

--- a/R/dep_get_index.R
+++ b/R/dep_get_index.R
@@ -9,12 +9,6 @@
 #'     the neighborhood deprivation index (NDI; via \code{ndi}). Both ADI and NDI
 #'     contain variations as well. See Details for more information.
 #'
-#' @usage dep_get_index(geography, index, year, survey = "acs5",
-#'     return_percentiles = FALSE, keep_subscales = FALSE,
-#'     keep_components = FALSE, output = "wide",
-#'     state = NULL, county = NULL, puerto_rico = FALSE, zcta = NULL,
-#'     zcta_geo_method = NULL, zcta_cb = FALSE, zcta3_method = NULL,
-#'     shift_geo = FALSE, key = NULL)
 #'
 #' @param geography A character scalar; one of \code{"county"}, \code{"zcta3"},
 #'     \code{"zcta5"}, or \code{"tract"}

--- a/R/dep_map_breaks.R
+++ b/R/dep_map_breaks.R
@@ -4,8 +4,6 @@
 #'     \code{ggplot2} or \code{leaflet}. The function can create the bins
 #'     automatically or will accept pre-specified breaks.
 #'
-#' @usage dep_map_breaks(.data, var, new_var, classes, style, breaks,
-#'     sig_digits = 2, return = "col", show_warnings = TRUE)
 #'
 #' @param .data A data object, either sf, tibble, or data.frame
 #' @param var Variable breaks should be based on, can be quoted or unquoted

--- a/R/dep_quantiles.R
+++ b/R/dep_quantiles.R
@@ -6,7 +6,6 @@
 #'     function supports splitting a distribution at the median (2 quantiles)
 #'     through deciles (10 quantiles) if character labels are desired.
 #'
-#' @usage dep_quantiles(.data, source_var, new_var, n = 4L, return = "label")
 #'
 #' @param .data A tibble containing the data to be used for calculating quantiles.
 #' @param source_var Required; the quoted or unquoted source variable to be

--- a/R/dep_rank.R
+++ b/R/dep_rank.R
@@ -3,7 +3,6 @@
 #' @description Calculate percentiles for a given variable in a data frame. This
 #'     is the method used to calculate ranked percentiles for SVI.
 #'
-#' @usage dep_percentiles(.data, source_var, new_var)
 #'
 #' @param .data A tibble containing the data to be used for calculating percentiles.
 #' @param source_var Required; the quoted or unquoted source variable to be

--- a/man/dep_calc_index.Rd
+++ b/man/dep_calc_index.Rd
@@ -4,9 +4,17 @@
 \alias{dep_calc_index}
 \title{Perform Deprivation Calculations}
 \usage{
-dep_calc_index(.data, geography, index, year, survey = "acs5",
-    return_percentiles = FALSE, keep_subscales = FALSE, keep_components = FALSE,
-    output = "wide")
+dep_calc_index(
+  .data,
+  geography,
+  index,
+  year,
+  survey = "acs5",
+  return_percentiles = FALSE,
+  keep_subscales = FALSE,
+  keep_components = FALSE,
+  output = "wide"
+)
 }
 \arguments{
 \item{.data}{A data frame, tibble, or \code{sf} object that contains all

--- a/man/dep_get_index.Rd
+++ b/man/dep_get_index.Rd
@@ -4,12 +4,25 @@
 \alias{dep_get_index}
 \title{Calculate Deprivation Measures}
 \usage{
-dep_get_index(geography, index, year, survey = "acs5",
-    return_percentiles = FALSE, keep_subscales = FALSE,
-    keep_components = FALSE, output = "wide",
-    state = NULL, county = NULL, puerto_rico = FALSE, zcta = NULL,
-    zcta_geo_method = NULL, zcta_cb = FALSE, zcta3_method = NULL,
-    shift_geo = FALSE, key = NULL)
+dep_get_index(
+  geography,
+  index,
+  year,
+  survey = "acs5",
+  return_percentiles = FALSE,
+  keep_subscales = FALSE,
+  keep_components = FALSE,
+  output = "wide",
+  state = NULL,
+  county = NULL,
+  puerto_rico = FALSE,
+  zcta = NULL,
+  zcta_geo_method = NULL,
+  zcta_cb = FALSE,
+  zcta3_method = NULL,
+  shift_geo = FALSE,
+  key = NULL
+)
 }
 \arguments{
 \item{geography}{A character scalar; one of \code{"county"}, \code{"zcta3"},

--- a/man/dep_map_breaks.Rd
+++ b/man/dep_map_breaks.Rd
@@ -4,8 +4,17 @@
 \alias{dep_map_breaks}
 \title{Calculating Map Breaks}
 \usage{
-dep_map_breaks(.data, var, new_var, classes, style, breaks,
-    sig_digits = 2, return = "col", show_warnings = TRUE)
+dep_map_breaks(
+  .data,
+  var,
+  new_var,
+  classes,
+  style,
+  breaks,
+  sig_digits = 2,
+  return = "col",
+  show_warnings = TRUE
+)
 }
 \arguments{
 \item{.data}{A data object, either sf, tibble, or data.frame}


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Removes manually written `@usage` roxygen2 tags from 6 function documentation files. roxygen2 auto-generates usage sections from function signatures, making manual tags redundant and a maintenance burden (they drift when signatures change).

## Implementation

- Removed `@usage` from: `dep_calc_index.R`, `dep_quantiles.R`, `dep_build_varlist.R`, `dep_get_index.R`, `dep_rank.R`, `dep_map_breaks.R`
- Retained `@usage` in `dep_sample_data.R` (data object with no function signature)
- Regenerated `.Rd` files via `devtools::document()`

## Testing

- `R CMD check` passes with 0 errors, 0 warnings, 0 notes
- Verified auto-generated usage in `.Rd` files matches function signatures

## Closes

Closes #40

## Notes

- Part of Epic A (#15): CRAN Compliance & Release Readiness
- UAT: R/ source changes reviewed and approved by maintainer prior to commit
<!-- pr-skill-managed-end -->
