### PR TITLE
feat: remove english, tidyselect, and tibble dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Removed manual `@usage` roxygen2 tags from function documentation; usage is now auto-generated from signatures (#40)
 - Migrated all `stop()`/`warning()`/`message()` calls to `cli::cli_abort()`/`cli::cli_warn()`/`cli::cli_inform()` for tidyverse-style formatted error messages (#28)
+- Removed `english`, `tibble`, and `tidyselect` from Imports; replaced with `dplyr` re-exports (14 → 11 dependencies) (#44)
 - Bumped minimum R version from 4.1 to 4.4 (required by Matrix package dependency chain)
 - Bumped minimum R version from 3.5 to 4.1 (#5)
 - Removed stale `CRAN-SUBMISSION` file from v0.1.0 (#7)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,15 +26,12 @@ Imports:
     classInt,
     cli,
     dplyr,
-    english,
     ndi,
     rlang,
     sf,
     sociome,
     stringr,
-    tibble,
     tidycensus,
-    tidyselect,
     tidyr, 
     zippeR
 Suggests:

--- a/R/dep_calc_index.R
+++ b/R/dep_calc_index.R
@@ -262,7 +262,7 @@ dep_calc_index <- function(.data, geography, index, year, survey = "acs5",
 
   # prep output
   if (output == "wide"){
-    out <- tibble::as_tibble(out)
+    out <- dplyr::as_tibble(out)
   }
 
   # return output

--- a/R/dep_get_data.R
+++ b/R/dep_get_data.R
@@ -229,7 +229,7 @@ dep_get_zcta5 <- function(varlist, year, survey, state, county,
     }
 
   } else if (geometry == FALSE){
-    geo <- tibble::as_tibble(data.frame(GEOID = demo$GEOID))
+    geo <- dplyr::as_tibble(data.frame(GEOID = demo$GEOID))
   }
 
   ## construct output
@@ -346,7 +346,7 @@ dep_get_zcta3 <- function(varlist, year, survey, state, county,
     }
 
   } else if (geometry == FALSE){
-    geo <- tibble::as_tibble(data.frame(GEOID = demo$GEOID))
+    geo <- dplyr::as_tibble(data.frame(GEOID = demo$GEOID))
   }
 
   ## construct output

--- a/R/dep_process.R
+++ b/R/dep_process.R
@@ -162,7 +162,7 @@ dep_process <- function(.data, geography, index, year, survey,
   # prep output
   if (output == "wide"){
 
-    out <- tibble::as_tibble(out)
+    out <- dplyr::as_tibble(out)
 
   } else if (output == "tidy"){
 

--- a/R/dep_quantiles.R
+++ b/R/dep_quantiles.R
@@ -199,12 +199,27 @@ dep_quantile_label <- function(x){
 
 dep_ordinal <- function(x){
 
-  ## create title case after ordinal conversion
-  out <- paste0(toupper(substr(english::ordinal(x), 1, 1)),
-                substr(english::ordinal(x), 2,
-                       nchar(english::ordinal(x))
-                       )
-                )
+  ## lookup table for word-form ordinals (title case)
+  ordinal_words <- c(
+    "First", "Second", "Third", "Fourth", "Fifth",
+    "Sixth", "Seventh", "Eighth", "Ninth", "Tenth",
+    "Eleventh", "Twelfth", "Thirteenth", "Fourteenth", "Fifteenth",
+    "Sixteenth", "Seventeenth", "Eighteenth", "Nineteenth", "Twentieth"
+  )
+
+  ## use lookup for 1-20, fallback to numeric suffix for higher values
+  suffix_map <- c("1" = "st", "2" = "nd", "3" = "rd")
+  numeric_suffix <- ifelse(
+    x %% 100 %in% 11:13, "th",
+    ifelse(as.character(x %% 10) %in% names(suffix_map),
+           suffix_map[as.character(x %% 10)], "th")
+  )
+
+  out <- ifelse(
+    x >= 1 & x <= 20,
+    ordinal_words[x],
+    paste0(x, numeric_suffix)
+  )
 
   ## return output
   return(out)

--- a/R/dep_utils.R
+++ b/R/dep_utils.R
@@ -1,6 +1,6 @@
 pivot_demos <- function(.data, vars){
 
-  out <- tidyr::pivot_longer(.data, cols = tidyselect::all_of(vars), names_to = "variable", values_to = "values")
+  out <- tidyr::pivot_longer(.data, cols = dplyr::all_of(vars), names_to = "variable", values_to = "values")
   out$variable <- ifelse(grepl("E", out$variable, fixed = TRUE) == TRUE, "estimate", "moe")
 
   out <- suppressWarnings(tidyr::pivot_wider(out, id_cols = GEOID, names_from = variable, values_from = values))

--- a/docs/OBJECTIVES.md
+++ b/docs/OBJECTIVES.md
@@ -23,6 +23,7 @@ quadrant: governance
 
 **Supporting epics:**
 - [Epic C] Documentation and User Onboarding (#17)
+- [Epic F] Code Quality & Test Coverage (#52)
 
 **Completed epics:**
 - [Epic A] CRAN Compliance and Release Readiness (#15) - closed 2026-05-27

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 
 ## Next
 
-_(empty)_
+- [Epic F] Code Quality & Test Coverage (#52) — `priority: medium`
 
 ## Later
 

--- a/docs/requirements/code-quality-test-coverage.md
+++ b/docs/requirements/code-quality-test-coverage.md
@@ -1,0 +1,49 @@
+---
+status: draft
+owner: prenec
+created: 2026-05-29
+last-updated: 2026-05-29
+related-epic(s): TBD (Epic F, not yet filed)
+---
+# Requirements: Code Quality & Test Coverage
+
+## 1. Background
+
+The deprivateR package has grown through five epics (A–E) focused on CRAN compliance, test quality, documentation, new features, and dependency reduction. With that foundation in place, a systematic audit of both source code quality and test coverage is needed to identify remaining gaps before the next feature push. Currently, 7 of 16 R source files have no corresponding test file (notably the `dep_process_*` family and `dep_get_data.R`), and no formal code quality analysis has been performed to surface maintainability or performance improvements.
+
+## 2. Sources
+
+- **S1.** Repo file listing — 16 R source files, 9 test files; coverage gap is visible from file-count mismatch alone.
+- **S2.** Quick-capture issues #50 and #51 — user-identified need for both source code and test analysis.
+- **S3.** Prior Epic B (Test Quality & Developer Experience, #16) — established the testing framework but focused on test infrastructure rather than comprehensive coverage analysis.
+
+## 3. Requirements
+
+### R1. Produce a test coverage report
+
+- **Rationale:** Without a quantitative baseline, prioritizing test gaps is guesswork.
+- **Source(s):** S1, S2
+- **Acceptance criteria:** A per-file and per-function coverage report exists (e.g., via `covr`); coverage percentage is known for every exported function.
+- **Out of scope:** Achieving a specific coverage target (that's a follow-up decision).
+- **Notes:** The report should identify both line coverage and branch coverage where tooling supports it.
+
+### R2. Identify and prioritize untested code paths
+
+- **Rationale:** Not all coverage gaps are equal — core computation functions (e.g., `dep_process_adi`, `dep_calc_index`) carry higher regression risk than utility helpers.
+- **Source(s):** S1, S3
+- **Acceptance criteria:** A prioritized list of untested functions/code paths exists, ranked by risk (exported vs. internal, complexity, user-facing impact).
+- **Out of scope:** Writing the tests themselves (that's follow-up work filed as sub-issues).
+
+### R3. Conduct source code quality analysis
+
+- **Rationale:** Code quality issues (duplicated logic, overly complex functions, inconsistent patterns) accumulate over time and increase maintenance cost.
+- **Source(s):** S2
+- **Acceptance criteria:** A documented analysis identifies concrete improvement opportunities (e.g., function decomposition, pattern standardization, performance hotspots) with actionable recommendations.
+- **Out of scope:** Implementing the improvements (follow-up issues).
+
+### R4. File follow-up issues for identified gaps
+
+- **Rationale:** The analysis is only valuable if it produces actionable backlog items.
+- **Source(s):** S2, S3
+- **Acceptance criteria:** Each significant finding (coverage gap or code quality issue) has a corresponding GitHub issue filed under Epic F with acceptance criteria.
+- **Out of scope:** Prioritizing the follow-up issues (that's triage/grooming work).

--- a/tests/testthat/test_dep_utils.R
+++ b/tests/testthat/test_dep_utils.R
@@ -64,7 +64,7 @@ test_that("validate_state returns NULL for NULL input", {
 
 test_that("pivot_demos aggregates estimate and moe columns", {
   # Create minimal test data mimicking Census format
-  test_df <- tibble::tibble(
+  test_df <- dplyr::tibble(
     GEOID = rep(c("29001", "29003"), each = 1),
     B01001_001E = c(100, 200),
     B01001_001M = c(10, 20)


### PR DESCRIPTION
## Summary

Removes three low-effort dependencies (`english`, `tidyselect`, `tibble`) identified in the dependency reduction research (#36), reducing explicit Imports from 14 to 11. All replaced functionality is available via `dplyr` re-exports.

## Implementation

- **`english`**: Replaced `english::ordinal()` with an internal `dep_ordinal()` helper using a lookup table for word-form ordinals 1–20, with a vectorized numeric suffix fallback for higher values.
- **`tibble`**: Replaced `tibble::as_tibble()` → `dplyr::as_tibble()` in 4 locations across `dep_calc_index.R`, `dep_process.R`, and `dep_get_data.R`.
- **`tidyselect`**: Replaced `tidyselect::all_of()` → `dplyr::all_of()` in `dep_utils.R`.
- Removed all three packages from DESCRIPTION Imports.
- Fixed a test file that used `tibble::tibble()` directly.

## Testing

- All 186 existing tests pass (FAIL 0 | WARN 0 | SKIP 1 | PASS 186)
- R CMD check: 0 errors, 0 warnings, 0 notes
- Code review caught and fixed a vectorization bug in the ordinal fallback path (`switch()` is not vectorized in R)
- ⚠️ **UAT note**: R/ source code modified — changes reviewed and approved by maintainer before commit

## Closes

Closes #44

## Notes

- No public API changes — all replacements are internal
- The `dep_ordinal()` fallback (>20) was rewritten to use vectorized `ifelse()` instead of non-vectorized `switch()` after code review
