### PR TITLE
feat: remove stringr dependency (Phase 2 dependency reduction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed manual `@usage` roxygen2 tags from function documentation; usage is now auto-generated from signatures (#40)
 - Migrated all `stop()`/`warning()`/`message()` calls to `cli::cli_abort()`/`cli::cli_warn()`/`cli::cli_inform()` for tidyverse-style formatted error messages (#28)
 - Removed `english`, `tibble`, and `tidyselect` from Imports; replaced with `dplyr` re-exports (14 → 11 dependencies) (#44)
+- Removed `stringr` from Imports; replaced with `trimws()` and internal `.dep_str_word()` helper (11 → 10 dependencies) (#43)
 - Bumped minimum R version from 4.1 to 4.4 (required by Matrix package dependency chain)
 - Bumped minimum R version from 3.5 to 4.1 (#5)
 - Removed stale `CRAN-SUBMISSION` file from v0.1.0 (#7)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Imports:
     rlang,
     sf,
     sociome,
-    stringr,
     tidycensus,
     tidyr, 
     zippeR

--- a/R/dep_build_varlist.R
+++ b/R/dep_build_varlist.R
@@ -419,9 +419,9 @@ dep_expand_varlist <- function(geography, index, year, survey,
                           "svi10, eng", "svi14, eng", "svi20, eng", "svi20s, eng",
                           "svi10, htt", "svi14, htt", "svi20, htt", "svi20s, htt") == TRUE){
 
-    req <- paste0(stringr::word(index, 2),"_vars")
+    req <- paste0(.dep_str_word(index, 2),"_vars")
 
-    if (stringr::word(index, 1) == "svi10,"){
+    if (.dep_str_word(index, 1) == "svi10,"){
 
       if (year %in% c(2010:2014) == TRUE){
         out <- request_vars$svi10_10[[req]]
@@ -431,7 +431,7 @@ dep_expand_varlist <- function(geography, index, year, survey,
         out <- request_vars$svi10_17[[req]]
       }
 
-    } else if (stringr::word(index, 1) == "svi14,"){
+    } else if (.dep_str_word(index, 1) == "svi14,"){
 
       if (year %in% c(2012:2014) == TRUE){
         out <- request_vars$svi14_12[[req]]
@@ -441,7 +441,7 @@ dep_expand_varlist <- function(geography, index, year, survey,
         out <- request_vars$svi14_17[[req]]
       }
 
-    } else if (stringr::word(index, 1) == "svi20,"){
+    } else if (.dep_str_word(index, 1) == "svi20,"){
 
       if (year == 2012){
         out <- request_vars$svi20_12[[req]]
@@ -452,7 +452,7 @@ dep_expand_varlist <- function(geography, index, year, survey,
       } else if (year %in% c(2017:2022) == TRUE){
         out <- request_vars$svi20_17[[req]]
       }
-    } else if (stringr::word(index, 1) == "svi20s,"){
+    } else if (.dep_str_word(index, 1) == "svi20s,"){
       out <- request_vars$svi20s_19[[req]]
     }
   }
@@ -509,5 +509,17 @@ dep_build_multi_varlist <- function(geography, index, year, survey){
   ## return output
   return(out)
 
+}
+
+
+# Internal helper: extract the nth word from a string (space-separated)
+# Matches stringr::word() behavior: returns NA for NA input, empty strings,
+# or out-of-bounds index
+.dep_str_word <- function(x, n) {
+  if (is.na(x)) return(NA_character_)
+  if (!nzchar(x)) return("")
+  words <- strsplit(trimws(x), "\\s+")[[1]]
+  if (n > length(words) || n < 1) return(NA_character_)
+  words[n]
 }
 

--- a/R/dep_utils.R
+++ b/R/dep_utils.R
@@ -28,7 +28,7 @@ validate_state <- function(state, .msg=interactive()) {
   # original tigris function
   if (is.null(state)) return(NULL)
 
-  state <- tolower(stringr::str_trim(state)) # forgive white space
+  state <- tolower(trimws(state)) # forgive white space
 
   if (grepl("^[[:digit:]]+$", state)) { # we prbly have FIPS
 

--- a/tests/testthat/test_dep_str_word.R
+++ b/tests/testthat/test_dep_str_word.R
@@ -1,0 +1,17 @@
+test_that(".dep_str_word extracts the correct word", {
+  expect_equal(.dep_str_word("svi10, hhd", 1), "svi10,")
+  expect_equal(.dep_str_word("svi10, hhd", 2), "hhd")
+  expect_equal(.dep_str_word("one two three", 3), "three")
+})
+
+test_that(".dep_str_word returns NA for edge cases", {
+  expect_equal(.dep_str_word(NA, 1), NA_character_)
+  expect_equal(.dep_str_word("", 1), "")
+  expect_equal(.dep_str_word("one", 5), NA_character_)
+  expect_equal(.dep_str_word("word", 0), NA_character_)
+})
+
+test_that(".dep_str_word handles multiple spaces", {
+  expect_equal(.dep_str_word("  svi20,   eng  ", 1), "svi20,")
+  expect_equal(.dep_str_word("  svi20,   eng  ", 2), "eng")
+})


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Remove `stringr` dependency by replacing its 6 call sites with base R equivalents, reducing the package's explicit Imports from 11 to 10 and eliminating the `stringi` transitive dependency. Phase 2 of Epic E (Dependency Reduction, #46).

## Implementation

- `stringr::str_trim(state)` → `trimws(state)` in `R/dep_utils.R`
- `stringr::word(index, n)` → internal `.dep_str_word(index, n)` helper in `R/dep_build_varlist.R`
- Helper uses `strsplit()` + indexing with edge-case handling matching `stringr::word()` behavior
- `stringr` removed from DESCRIPTION Imports

## Testing

- All 195 tests pass (186 existing + 9 new helper tests)
- `R CMD check` clean: 0 errors, 0 warnings, 0 notes
- New test file: `tests/testthat/test_dep_str_word.R` covering word extraction, NA input, empty strings, out-of-bounds, and multiple spaces

## Closes

- Closes #43

## Notes

- Code review identified one edge-case mismatch (`stringr::word("", 1)` returns `""` not `NA`); fixed before PR.
- No public API changes. All existing tests pass unchanged.
- Also eliminates `stringi` (large compiled C library) as a transitive dependency → faster installs.
<!-- pr-skill-managed-end -->
