### PR TITLE
refactor: extract dep_safe_pct() and dep_derived_moe() helpers (#60, #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Extracted `dep_safe_pct()` and `dep_derived_moe()` internal helpers, replacing ~78 hand-written formula instances across NDI and SVI processing functions; zero denominators now produce `NA` instead of `Inf`/`NaN` (#60, #61)
 - Removed manual `@usage` roxygen2 tags from function documentation; usage is now auto-generated from signatures (#40)
 - Migrated all `stop()`/`warning()`/`message()` calls to `cli::cli_abort()`/`cli::cli_warn()`/`cli::cli_inform()` for tidyverse-style formatted error messages (#28)
 - Removed `english`, `tibble`, and `tidyselect` from Imports; replaced with `dplyr` re-exports (14 → 11 dependencies) (#44)

--- a/R/dep_process_ndi.R
+++ b/R/dep_process_ndi.R
@@ -30,14 +30,14 @@ dep_process_ndi_m <- function(.data, geography, year, survey, keep_components,
     .data$B19001_005E+.data$B19001_006E
 
   ## calculate metrics
-  .data$EP_MPRO <- .data$E_MPRO/.data$D_MPRO*100
-  .data$EP_CROWD <- .data$E_CROWD/.data$E_HH*100
-  .data$EP_POVH <- .data$E_POVH/.data$E_HH*100
-  .data$EP_FFH <- .data$E_FFH/.data$E_HH*100
-  .data$EP_ASSIST <- .data$E_ASSIST/.data$E_HH*100
-  .data$EP_LOWINC <- .data$E_LOWINC/.data$E_HH*100
-  .data$EP_LTHS <- .data$E_LTHS/.data$D_EDU*100
-  .data$EP_UNEMP <- .data$E_UNEMP/.data$D_UNEMP*100
+  .data$EP_MPRO <- dep_safe_pct(.data$E_MPRO, .data$D_MPRO)
+  .data$EP_CROWD <- dep_safe_pct(.data$E_CROWD, .data$E_HH)
+  .data$EP_POVH <- dep_safe_pct(.data$E_POVH, .data$E_HH)
+  .data$EP_FFH <- dep_safe_pct(.data$E_FFH, .data$E_HH)
+  .data$EP_ASSIST <- dep_safe_pct(.data$E_ASSIST, .data$E_HH)
+  .data$EP_LOWINC <- dep_safe_pct(.data$E_LOWINC, .data$E_HH)
+  .data$EP_LTHS <- dep_safe_pct(.data$E_LTHS, .data$D_EDU)
+  .data$EP_UNEMP <- dep_safe_pct(.data$E_UNEMP, .data$D_UNEMP)
 
   ## prep for scoring
   ndi_m_score <- subset(.data, select = c(GEOID, EP_MPRO, EP_CROWD, EP_POVH, EP_FFH,
@@ -82,14 +82,14 @@ dep_process_ndi_m <- function(.data, geography, year, survey, keep_components,
     .data$M_LOWINC <- sqrt(.data$B19001_002M^2+.data$B19001_003M^2+.data$B19001_004M^2+
                              .data$B19001_005M^2+.data$B19001_006M^2)
 
-    .data$MP_MPRO <- ((sqrt(.data$M_MPRO^2-((.data$EP_MPRO/100)^2*.data$DM_MPRO^2)))/.data$DM_MPRO)*100
-    .data$MP_CROWD <- ((sqrt(.data$M_CROWD^2-((.data$EP_CROWD/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_POVH <- ((sqrt(.data$M_POVH^2-((.data$EP_POVH/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_FFH <- ((sqrt(.data$M_FFH^2-((.data$EP_FFH/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_ASSIST <- ((sqrt(.data$M_ASSIST^2-((.data$EP_ASSIST/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_LOWINC <- ((sqrt(.data$M_LOWINC^2-((.data$EP_LOWINC/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_LTHS <- ((sqrt(.data$M_LTHS^2-((.data$EP_LTHS/100)^2*.data$DM_EDU^2)))/.data$DM_EDU)*100
-    .data$MP_UNEMP <- ((sqrt(.data$M_UNEMP^2-((.data$EP_UNEMP/100)^2*.data$DM_UNEMP^2)))/.data$DM_UNEMP)*100
+    .data$MP_MPRO <- dep_derived_moe(.data$M_MPRO, .data$EP_MPRO, .data$DM_MPRO, .data$DM_MPRO)
+    .data$MP_CROWD <- dep_derived_moe(.data$M_CROWD, .data$EP_CROWD, .data$M_HH, .data$M_HH)
+    .data$MP_POVH <- dep_derived_moe(.data$M_POVH, .data$EP_POVH, .data$M_HH, .data$M_HH)
+    .data$MP_FFH <- dep_derived_moe(.data$M_FFH, .data$EP_FFH, .data$M_HH, .data$M_HH)
+    .data$MP_ASSIST <- dep_derived_moe(.data$M_ASSIST, .data$EP_ASSIST, .data$M_HH, .data$M_HH)
+    .data$MP_LOWINC <- dep_derived_moe(.data$M_LOWINC, .data$EP_LOWINC, .data$M_HH, .data$M_HH)
+    .data$MP_LTHS <- dep_derived_moe(.data$M_LTHS, .data$EP_LTHS, .data$DM_EDU, .data$DM_EDU)
+    .data$MP_UNEMP <- dep_derived_moe(.data$M_UNEMP, .data$EP_UNEMP, .data$DM_UNEMP, .data$DM_UNEMP)
 
     ### reorder variables
     .data <- subset(.data, select = c(GEOID, E_HH, M_HH,
@@ -144,23 +144,23 @@ dep_process_ndi_pw <- function(.data, geography, year, survey, keep_components,
   names(.data)[names(.data) == "DP03_0005E"] <- "E_UNEMP"
 
   ## calculate components
-  .data$EP_INVINC <- .data$E_INVINC/.data$E_HH*100
+  .data$EP_INVINC <- dep_safe_pct(.data$E_INVINC, .data$E_HH)
   .data$EP_NO_INVINC <- 100 - .data$EP_INVINC
-  .data$EP_ASSIST <- .data$E_ASSIST/.data$E_HH*100
+  .data$EP_ASSIST <- dep_safe_pct(.data$E_ASSIST, .data$E_HH)
   .data$EP_NO_ASSIST <- 100 - .data$EP_ASSIST
-  .data$EP_MANAGE <- .data$E_MANAGE/.data$D_MANAGE*100
+  .data$EP_MANAGE <- dep_safe_pct(.data$E_MANAGE, .data$D_MANAGE)
   .data$EP_WORKER <- 100 - .data$EP_MANAGE
   .data$E_FEMHH <- .data$B11005_007E + .data$B11005_010E
-  .data$EP_FEMHH <- .data$E_FEMHH/.data$E_HH*100
-  .data$EP_OWNOCC <- .data$E_OWNOCC/.data$E_HH*100
+  .data$EP_FEMHH <- dep_safe_pct(.data$E_FEMHH, .data$E_HH)
+  .data$EP_OWNOCC <- dep_safe_pct(.data$E_OWNOCC, .data$E_HH)
   .data$EP_NO_OWNOCC <- 100 - .data$EP_OWNOCC
-  .data$EP_NOPLUMB <- .data$E_NOPLUMB/.data$E_HH*100
-  .data$EP_NOPHONE <- .data$E_NOPHONE/.data$E_HH*100
-  .data$EP_HSPLUS <- .data$E_HSPLUS/.data$D_HIGHDEG*100
+  .data$EP_NOPLUMB <- dep_safe_pct(.data$E_NOPLUMB, .data$E_HH)
+  .data$EP_NOPHONE <- dep_safe_pct(.data$E_NOPHONE, .data$E_HH)
+  .data$EP_HSPLUS <- dep_safe_pct(.data$E_HSPLUS, .data$D_HIGHDEG)
   .data$EP_LTHS <- 100 - .data$EP_HSPLUS
-  .data$EP_BAPLUS <- .data$E_BAPLUS/.data$D_HIGHDEG*100
+  .data$EP_BAPLUS <- dep_safe_pct(.data$E_BAPLUS, .data$D_HIGHDEG)
   .data$EP_LTBA <- 100 - .data$EP_BAPLUS
-  .data$EP_UNEMP <- .data$E_UNEMP/.data$D_UNEMP*100
+  .data$EP_UNEMP <- dep_safe_pct(.data$E_UNEMP, .data$D_UNEMP)
 
   ## calculate metrics
   .data$EL_HHINC <- log(.data$E_HHINC)
@@ -230,17 +230,17 @@ dep_process_ndi_pw <- function(.data, geography, year, survey, keep_components,
     names(.data)[names(.data) == "DP03_0005M"] <- "M_UNEMP"
 
     ### calculate margins of error
-    .data$MP_INVINC <- ((sqrt(.data$M_INVINC^2-((.data$EP_INVINC/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_ASSIST <- ((sqrt(.data$M_ASSIST^2-((.data$EP_ASSIST/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_MANAGE <- ((sqrt(.data$M_MANAGE^2-((.data$EP_MANAGE/100)^2*.data$DM_MANAGE^2)))/.data$DM_MANAGE)*100
+    .data$MP_INVINC <- dep_derived_moe(.data$M_INVINC, .data$EP_INVINC, .data$M_HH, .data$M_HH)
+    .data$MP_ASSIST <- dep_derived_moe(.data$M_ASSIST, .data$EP_ASSIST, .data$M_HH, .data$M_HH)
+    .data$MP_MANAGE <- dep_derived_moe(.data$M_MANAGE, .data$EP_MANAGE, .data$DM_MANAGE, .data$DM_MANAGE)
     .data$M_FEMHH <- sqrt(.data$B11005_007M^2+.data$B11005_010M^2)
-    .data$MP_FEMHH <- ((sqrt(.data$M_FEMHH^2-((.data$EP_FEMHH/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_OWNOCC <- ((sqrt(.data$M_OWNOCC^2-((.data$EP_OWNOCC/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_NOPLUMB <- ((sqrt(.data$M_NOPLUMB^2-((.data$EP_NOPLUMB/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_NOPHONE <- ((sqrt(.data$M_NOPHONE^2-((.data$EP_NOPHONE/100)^2*.data$M_HH^2)))/.data$M_HH)*100
-    .data$MP_HSPLUS <- ((sqrt(.data$M_HSPLUS^2-((.data$EP_HSPLUS/100)^2*.data$DM_HIGHDEG^2)))/.data$DM_HIGHDEG)*100
-    .data$MP_BAPLUS <- ((sqrt(.data$M_BAPLUS^2-((.data$EP_BAPLUS/100)^2*.data$DM_HIGHDEG^2)))/.data$DM_HIGHDEG)*100
-    .data$MP_UNEMP <- ((sqrt(.data$M_UNEMP^2-((.data$EP_UNEMP/100)^2*.data$DM_UNEMP^2)))/.data$DM_UNEMP)*100
+    .data$MP_FEMHH <- dep_derived_moe(.data$M_FEMHH, .data$EP_FEMHH, .data$M_HH, .data$M_HH)
+    .data$MP_OWNOCC <- dep_derived_moe(.data$M_OWNOCC, .data$EP_OWNOCC, .data$M_HH, .data$M_HH)
+    .data$MP_NOPLUMB <- dep_derived_moe(.data$M_NOPLUMB, .data$EP_NOPLUMB, .data$M_HH, .data$M_HH)
+    .data$MP_NOPHONE <- dep_derived_moe(.data$M_NOPHONE, .data$EP_NOPHONE, .data$M_HH, .data$M_HH)
+    .data$MP_HSPLUS <- dep_derived_moe(.data$M_HSPLUS, .data$EP_HSPLUS, .data$DM_HIGHDEG, .data$DM_HIGHDEG)
+    .data$MP_BAPLUS <- dep_derived_moe(.data$M_BAPLUS, .data$EP_BAPLUS, .data$DM_HIGHDEG, .data$DM_HIGHDEG)
+    .data$MP_UNEMP <- dep_derived_moe(.data$M_UNEMP, .data$EP_UNEMP, .data$DM_UNEMP, .data$DM_UNEMP)
 
     ### reorder variables
     .data <- subset(.data, select = c(GEOID, E_TOTPOP, M_TOTPOP, E_HH, M_HH,

--- a/R/dep_process_svi.R
+++ b/R/dep_process_svi.R
@@ -283,31 +283,31 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
   }
 
   ## calculate metrics
-  out$EP_NOHSDP <- out$E_NOHSDP/out$D_NOHSDP*100
-  out$MP_NOHSDP <- ((sqrt(out$M_NOHSDP^2-((out$EP_NOHSDP/100)^2*out$DM_NOHSDP^2)))/out$DM_NOHSDP)*100
+  out$EP_NOHSDP <- dep_safe_pct(out$E_NOHSDP, out$D_NOHSDP)
+  out$MP_NOHSDP <- dep_derived_moe(out$M_NOHSDP, out$EP_NOHSDP, out$DM_NOHSDP, out$DM_NOHSDP)
 
-  out$EP_UNEMP <- out$E_UNEMP/out$D_UNEMP*100
-  out$MP_UNEMP <- ((sqrt(out$M_UNEMP^2-((out$EP_UNEMP/100)^2*out$DM_UNEMP^2)))/out$DM_UNEMP)*100
+  out$EP_UNEMP <- dep_safe_pct(out$E_UNEMP, out$D_UNEMP)
+  out$MP_UNEMP <- dep_derived_moe(out$M_UNEMP, out$EP_UNEMP, out$DM_UNEMP, out$DM_UNEMP)
 
   if (style %in% c("svi10", "svi14") == TRUE){
 
-    out$EP_POV <- out$E_POV/out$D_POV*100
-    out$MP_POV <- ((sqrt(out$M_POV^2-((out$EP_POV/100)^2*out$DM_POV^2)))/out$DM_POV)*100
+    out$EP_POV <- dep_safe_pct(out$E_POV, out$D_POV)
+    out$MP_POV <- dep_derived_moe(out$M_POV, out$EP_POV, out$DM_POV, out$DM_POV)
 
   } else if (style %in% c("svi20", "svi20s") == TRUE){
 
-    out$EP_POV150 <- out$E_POV150/out$D_POV150*100
-    out$MP_POV150 <- ((sqrt(out$M_POV150^2-((out$EP_POV150/100)^2*out$DM_POV150^2)))/out$DM_POV150)*100
+    out$EP_POV150 <- dep_safe_pct(out$E_POV150, out$D_POV150)
+    out$MP_POV150 <- dep_derived_moe(out$M_POV150, out$EP_POV150, out$DM_POV150, out$DM_POV150)
 
-    out$EP_UNINSUR <- out$E_UNINSUR/out$D_UNINSUR*100
-    out$MP_UNINSUR <- ((sqrt(out$M_UNINSUR^2-((out$EP_UNINSUR/100)^2*out$DM_UNINSUR^2)))/out$DM_UNINSUR)*100
+    out$EP_UNINSUR <- dep_safe_pct(out$E_UNINSUR, out$D_UNINSUR)
+    out$MP_UNINSUR <- dep_derived_moe(out$M_UNINSUR, out$EP_UNINSUR, out$DM_UNINSUR, out$DM_UNINSUR)
 
     if (year < 2017){
       out$EP_HBURD <- out$E_HBURD
       out$MP_HBURD <- out$M_HBURD
     } else if (year >= 2017){
-      out$EP_HBURD <- out$E_HBURD/out$D_HBURD*100
-      out$MP_HBURD <- ((sqrt(out$M_HBURD^2-((out$EP_HBURD/100)^2*out$DM_HBURD^2)))/out$DM_HBURD)*100
+      out$EP_HBURD <- dep_safe_pct(out$E_HBURD, out$D_HBURD)
+      out$MP_HBURD <- dep_derived_moe(out$M_HBURD, out$EP_HBURD, out$DM_HBURD, out$DM_HBURD)
     }
 
   }
@@ -501,23 +501,23 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
   }
 
   ## calculate metrics
-  out$EP_AGE17 <- out$E_AGE17/out$D_AGE*100
-  out$MP_AGE17 <- ((sqrt(out$M_AGE17^2-((out$EP_AGE17/100)^2*out$DM_AGE^2)))/out$DM_AGE)*100
+  out$EP_AGE17 <- dep_safe_pct(out$E_AGE17, out$D_AGE)
+  out$MP_AGE17 <- dep_derived_moe(out$M_AGE17, out$EP_AGE17, out$DM_AGE, out$DM_AGE)
 
-  out$EP_AGE65 <- out$E_AGE65/out$D_AGE*100
-  out$MP_AGE65 <- ((sqrt(out$M_AGE65^2-((out$EP_AGE65/100)^2*out$DM_AGE^2)))/out$DM_AGE)*100
+  out$EP_AGE65 <- dep_safe_pct(out$E_AGE65, out$D_AGE)
+  out$MP_AGE65 <- dep_derived_moe(out$M_AGE65, out$EP_AGE65, out$DM_AGE, out$DM_AGE)
 
-  out$EP_SNGPNT <- out$E_SNGPNT/out$D_SNGPNT*100
-  out$MP_SNGPNT <- ((sqrt(out$M_SNGPNT^2-((out$EP_SNGPNT/100)^2*out$DM_SNGPNT^2)))/out$DM_SNGPNT)*100
+  out$EP_SNGPNT <- dep_safe_pct(out$E_SNGPNT, out$D_SNGPNT)
+  out$MP_SNGPNT <- dep_derived_moe(out$M_SNGPNT, out$EP_SNGPNT, out$DM_SNGPNT, out$DM_SNGPNT)
 
   if (style %in% c("svi14", "svi20", "svi20s") == TRUE){
-    out$EP_DISABL <- out$E_DISABL/out$D_DISABL*100
-    out$MP_DISABL <- ((sqrt(out$M_DISABL^2-((out$EP_DISABL/100)^2*out$DM_DISABL^2)))/out$DM_DISABL)*100
+    out$EP_DISABL <- dep_safe_pct(out$E_DISABL, out$D_DISABL)
+    out$MP_DISABL <- dep_derived_moe(out$M_DISABL, out$EP_DISABL, out$DM_DISABL, out$DM_DISABL)
   }
 
   if (style %in% c("svi20", "svi20s") == TRUE){
-    out$EP_LIMENG <- out$E_LIMENG/out$D_LIMENG*100
-    out$MP_LIMENG <- ((sqrt(out$M_LIMENG^2-((out$EP_LIMENG/100)^2*out$DM_LIMENG^2)))/out$DM_LIMENG)*100
+    out$EP_LIMENG <- dep_safe_pct(out$E_LIMENG, out$D_LIMENG)
+    out$MP_LIMENG <- dep_derived_moe(out$M_LIMENG, out$EP_LIMENG, out$DM_LIMENG, out$DM_LIMENG)
   }
 
   ## calculate percentiles
@@ -628,12 +628,12 @@ dep_process_svi_msl <- function(.data, style, geography, year, survey, keep_comp
   }
 
   ### calculate metrics
-  out$EP_MINRTY <- out$E_MINRTY/out$D_MINRTY*100
-  out$MP_MINRTY <- ((sqrt(out$M_MINRTY^2-((out$EP_MINRTY/100)^2*out$DM_MINRTY^2)))/out$DM_MINRTY)*100
+  out$EP_MINRTY <- dep_safe_pct(out$E_MINRTY, out$D_MINRTY)
+  out$MP_MINRTY <- dep_derived_moe(out$M_MINRTY, out$EP_MINRTY, out$DM_MINRTY, out$DM_MINRTY)
 
   if (style %in% c("svi10", "svi14")){
-    out$EP_LIMENG <- out$E_LIMENG/out$D_LIMENG*100
-    out$MP_LIMENG <- ((sqrt(out$M_LIMENG^2-((out$EP_LIMENG/100)^2*out$DM_LIMENG^2)))/out$DM_LIMENG)*100
+    out$EP_LIMENG <- dep_safe_pct(out$E_LIMENG, out$D_LIMENG)
+    out$MP_LIMENG <- dep_derived_moe(out$M_LIMENG, out$EP_LIMENG, out$DM_LIMENG, out$DM_LIMENG)
   }
 
   ## calculate percentiles
@@ -738,20 +738,20 @@ dep_process_svi_htt <- function(.data, style, geography, year, survey, keep_comp
   }
 
   ## calculate metrics
-  .data$EP_MUNIT <- .data$E_MUNIT/.data$D_HOUSE*100
-  .data$MP_MUNIT <- ((sqrt(.data$M_MUNIT^2-((.data$EP_MUNIT/100)^2*.data$DM_HOUSE^2)))/.data$DM_HOUSE)*100
+  .data$EP_MUNIT <- dep_safe_pct(.data$E_MUNIT, .data$D_HOUSE)
+  .data$MP_MUNIT <- dep_derived_moe(.data$M_MUNIT, .data$EP_MUNIT, .data$DM_HOUSE, .data$DM_HOUSE)
 
-  .data$EP_MOBILE <- .data$E_MOBILE/.data$D_HOUSE*100
-  .data$MP_MOBILE <- ((sqrt(.data$M_MOBILE^2-((.data$EP_MOBILE/100)^2*.data$DM_HOUSE^2)))/.data$DM_HOUSE)*100
+  .data$EP_MOBILE <- dep_safe_pct(.data$E_MOBILE, .data$D_HOUSE)
+  .data$MP_MOBILE <- dep_derived_moe(.data$M_MOBILE, .data$EP_MOBILE, .data$DM_HOUSE, .data$DM_HOUSE)
 
-  .data$EP_CROWD <- .data$E_CROWD/.data$D_CROWD*100
-  .data$MP_CROWD <- ((sqrt(.data$M_CROWD^2-((.data$EP_CROWD/100)^2*.data$DM_CROWD^2)))/.data$DM_CROWD)*100
+  .data$EP_CROWD <- dep_safe_pct(.data$E_CROWD, .data$D_CROWD)
+  .data$MP_CROWD <- dep_derived_moe(.data$M_CROWD, .data$EP_CROWD, .data$DM_CROWD, .data$DM_CROWD)
 
-  .data$EP_NOVEH <- .data$E_NOVEH/.data$D_NOVEH*100
-  .data$MP_NOVEH <- ((sqrt(.data$M_NOVEH^2-((.data$EP_NOVEH/100)^2*.data$DM_NOVEH^2)))/.data$DM_NOVEH)*100
+  .data$EP_NOVEH <- dep_safe_pct(.data$E_NOVEH, .data$D_NOVEH)
+  .data$MP_NOVEH <- dep_derived_moe(.data$M_NOVEH, .data$EP_NOVEH, .data$DM_NOVEH, .data$DM_NOVEH)
 
-  .data$EP_GROUPQ <- .data$E_GROUPQ/.data$S0101_C01_001E*100
-  .data$MP_GROUPQ <- ((sqrt(.data$M_GROUPQ^2-((.data$EP_GROUPQ/100)^2*.data$S0101_C01_001M^2)))/.data$S0101_C01_001M)*100
+  .data$EP_GROUPQ <- dep_safe_pct(.data$E_GROUPQ, .data$S0101_C01_001E)
+  .data$MP_GROUPQ <- dep_derived_moe(.data$M_GROUPQ, .data$EP_GROUPQ, .data$S0101_C01_001M, .data$S0101_C01_001M)
 
   ## calculate percentiles
   .data$EPL_MUNIT <- dep_percent_rank(.data$EP_MUNIT)

--- a/R/dep_utils.R
+++ b/R/dep_utils.R
@@ -14,6 +14,30 @@ pivot_demos <- function(.data, vars){
 }
 
 
+# Safe percentage calculation ---------------------------------------------
+# Returns NA_real_ when denominator is 0 or NA instead of Inf/NaN
+dep_safe_pct <- function(numerator, denominator) {
+  result <- ifelse(denominator == 0 | is.na(denominator),
+                   NA_real_,
+                   numerator / denominator * 100)
+  return(result)
+}
+
+
+# Derived margin of error for proportions ---------------------------------
+# Census-standard derived MOE formula:
+#   ((sqrt(M^2 - ((EP/100)^2 * DM^2))) / DM) * 100
+# Returns NA_real_ when denominator is 0/NA or radicand is negative
+dep_derived_moe <- function(estimate_moe, proportion, denominator_moe, denominator) {
+  radicand <- estimate_moe^2 - ((proportion / 100)^2 * denominator_moe^2)
+  invalid <- denominator == 0 | is.na(denominator) | radicand < 0 | is.na(radicand)
+  # Use pmax to avoid sqrt(negative) warnings; invalid cases are replaced with NA below
+  safe_radicand <- ifelse(invalid, 0, radicand)
+  result <- ifelse(invalid, NA_real_, (sqrt(safe_radicand) / denominator) * 100)
+  return(result)
+}
+
+
 # the functions below are from the tigris package that are not exported
 # https://github.com/walkerke/tigris/blob/master/R/utils.R
 # used based on terms of the MIT License used by the package's author, Kyle Walker

--- a/tests/testthat/test_dep_process_baseline.R
+++ b/tests/testthat/test_dep_process_baseline.R
@@ -1,0 +1,240 @@
+
+# Baseline snapshot tests for EP_ (percent) and MP_ (derived MOE) calculations
+# These tests capture exact numeric output of the current implementation to detect
+# drift when refactoring the formulas into helper functions (#60, #61).
+
+# setup: load sample data ------------------------------------------------
+
+ndi_m_data <- dep_sample_data(index = "ndi_m")
+ndi_pw_data <- dep_sample_data(index = "ndi_pw")
+svi20_data <- dep_sample_data(index = "svi20")
+svi10_data <- dep_sample_data(index = "svi10")
+
+# test NDI-M percent calculations (EP_) ----------------------------------
+
+test_that("dep_process_ndi_m EP_ columns match baseline values", {
+  result <- suppressWarnings(
+    dep_process_ndi_m(ndi_m_data, geography = "county",
+                      year = 2022, survey = "acs5",
+                      keep_components = TRUE, return_percentiles = FALSE)
+  )
+
+  # Row 1: GEOID 29001
+  expect_equal(result$EP_MPRO[1], 3.6293294031, tolerance = 1e-6)
+  expect_equal(result$EP_CROWD[1], 1.4440433213, tolerance = 1e-6)
+  expect_equal(result$EP_POVH[1], 22.111913357, tolerance = 1e-6)
+  expect_equal(result$EP_UNEMP[1], 5.464480874, tolerance = 1e-6)
+
+  # Row 2: GEOID 29003
+  expect_equal(result$EP_MPRO[2], 3.3920704846, tolerance = 1e-6)
+  expect_equal(result$EP_CROWD[2], 0.3204661326, tolerance = 1e-6)
+  expect_equal(result$EP_POVH[2], 9.934450109, tolerance = 1e-6)
+  expect_equal(result$EP_UNEMP[2], 4.148496030, tolerance = 1e-6)
+
+  # Row 3: GEOID 29005
+  expect_equal(result$EP_MPRO[3], 1.6061452514, tolerance = 1e-6)
+  expect_equal(result$EP_CROWD[3], 1.8715440238, tolerance = 1e-6)
+  expect_equal(result$EP_POVH[3], 12.505316886, tolerance = 1e-6)
+  expect_equal(result$EP_UNEMP[3], 2.601377200, tolerance = 1e-6)
+})
+
+# test NDI-M derived MOE calculations (MP_) ------------------------------
+
+test_that("dep_process_ndi_m MP_ columns match baseline values", {
+  result <- suppressWarnings(
+    dep_process_ndi_m(ndi_m_data, geography = "county",
+                      year = 2022, survey = "acs5",
+                      keep_components = TRUE, return_percentiles = FALSE)
+  )
+
+  # Row 1: GEOID 29001
+  expect_equal(result$MP_MPRO[1], 33.50595526, tolerance = 1e-4)
+  expect_equal(result$MP_CROWD[1], 24.012277771, tolerance = 1e-4)
+  expect_equal(result$MP_POVH[1], 91.91134564, tolerance = 1e-4)
+  expect_equal(result$MP_UNEMP[1], 48.13439383, tolerance = 1e-4)
+
+  # Row 2: GEOID 29003
+  expect_equal(result$MP_MPRO[2], 26.83444100, tolerance = 1e-4)
+  expect_equal(result$MP_CROWD[2], 8.798527786, tolerance = 1e-4)
+  expect_equal(result$MP_POVH[2], 118.07993792, tolerance = 1e-4)
+  expect_equal(result$MP_UNEMP[2], 32.96256297, tolerance = 1e-4)
+
+  # Row 3: GEOID 29005
+  expect_equal(result$MP_MPRO[3], 23.22321693, tolerance = 1e-4)
+  expect_equal(result$MP_CROWD[3], 39.985055277, tolerance = 1e-4)
+  expect_equal(result$MP_POVH[3], 71.05992922, tolerance = 1e-4)
+  expect_equal(result$MP_UNEMP[3], 32.21838271, tolerance = 1e-4)
+})
+
+# test SVI20 SES theme percent calculations (EP_) ------------------------
+
+test_that("dep_process_svi_ses EP_ columns match baseline for svi20", {
+  result <- suppressWarnings(
+    dep_process_svi_ses(svi20_data, style = "svi20", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  # Row 1: GEOID 29001
+  expect_equal(result$EP_NOHSDP[1], 8.00, tolerance = 0.01)
+  expect_equal(result$EP_UNEMP[1], 5.46, tolerance = 0.01)
+  expect_equal(result$EP_POV150[1], 32.9, tolerance = 0.1)
+  expect_equal(result$EP_UNINSUR[1], 8.06, tolerance = 0.01)
+
+  # Row 2: GEOID 29003
+  expect_equal(result$EP_NOHSDP[2], 5.53, tolerance = 0.01)
+  expect_equal(result$EP_UNEMP[2], 4.15, tolerance = 0.01)
+  expect_equal(result$EP_POV150[2], 14.7, tolerance = 0.1)
+  expect_equal(result$EP_UNINSUR[2], 6.31, tolerance = 0.01)
+})
+
+# test SVI20 SES theme derived MOE calculations (MP_) --------------------
+
+test_that("dep_process_svi_ses MP_ columns match baseline for svi20", {
+  result <- suppressWarnings(
+    dep_process_svi_ses(svi20_data, style = "svi20", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  # Row 1: GEOID 29001
+  expect_equal(result$MP_NOHSDP[1], 91.9, tolerance = 0.1)
+  expect_equal(result$MP_UNEMP[1], 48.1, tolerance = 0.1)
+  expect_equal(result$MP_POV150[1], 1144, tolerance = 1)
+
+  # Row 2: GEOID 29003
+  expect_equal(result$MP_NOHSDP[2], 161, tolerance = 1)
+  expect_equal(result$MP_UNEMP[2], 33.0, tolerance = 0.1)
+  expect_equal(result$MP_POV150[2], 389, tolerance = 1)
+})
+
+# test SVI20 HTT theme percent calculations (EP_) ------------------------
+
+test_that("dep_process_svi_htt EP_ columns match baseline for svi20", {
+  result <- suppressWarnings(
+    dep_process_svi_htt(svi20_data, style = "svi20", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  # Row 1: GEOID 29001
+  expect_equal(result$EP_MUNIT[1], 3.082614057, tolerance = 1e-6)
+  expect_equal(result$EP_MOBILE[1], 7.310199049, tolerance = 1e-6)
+  expect_equal(result$EP_CROWD[1], 1.4440433213, tolerance = 1e-6)
+  expect_equal(result$EP_NOVEH[1], 7.017148014, tolerance = 1e-6)
+  expect_equal(result$EP_GROUPQ[1], 9.447013716, tolerance = 1e-6)
+
+  # Row 2: GEOID 29003
+  expect_equal(result$EP_MUNIT[2], 2.243759958, tolerance = 1e-6)
+  expect_equal(result$EP_MOBILE[2], 6.186935741, tolerance = 1e-6)
+  expect_equal(result$EP_CROWD[2], 0.3204661326, tolerance = 1e-6)
+  expect_equal(result$EP_NOVEH[2], 3.481427531, tolerance = 1e-6)
+  expect_equal(result$EP_GROUPQ[2], 1.012784327, tolerance = 1e-6)
+})
+
+# test SVI20 HTT theme derived MOE calculations (MP_) --------------------
+
+test_that("dep_process_svi_htt MP_ columns match baseline for svi20", {
+  result <- suppressWarnings(
+    dep_process_svi_htt(svi20_data, style = "svi20", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  # Row 1: GEOID 29001
+  expect_equal(result$MP_MUNIT[1], 432.21900777, tolerance = 1e-2)
+  expect_equal(result$MP_MOBILE[1], 442.36384490, tolerance = 1e-2)
+  expect_equal(result$MP_CROWD[1], 24.012277771, tolerance = 1e-4)
+  expect_equal(result$MP_NOVEH[1], 49.01796355, tolerance = 1e-4)
+  # MP_GROUPQ is NA for row 1 (edge case — negative radicand)
+  expect_true(is.na(result$MP_GROUPQ[1]) || is.nan(result$MP_GROUPQ[1]))
+
+  # Row 2: GEOID 29003
+  expect_equal(result$MP_MUNIT[2], 367.29622379, tolerance = 1e-2)
+  expect_equal(result$MP_MOBILE[2], 309.61560988, tolerance = 1e-2)
+  expect_equal(result$MP_CROWD[2], 8.798527786, tolerance = 1e-4)
+  expect_equal(result$MP_NOVEH[2], 67.54039074, tolerance = 1e-4)
+})
+
+# test SVI10 style also produces consistent results ----------------------
+
+test_that("dep_process_svi_ses EP_ columns match baseline for svi10", {
+  result <- suppressWarnings(
+    dep_process_svi_ses(svi10_data, style = "svi10", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  # svi10 uses EP_POV instead of EP_POV150
+
+  expect_true("EP_POV" %in% names(result))
+  expect_true("EP_NOHSDP" %in% names(result))
+  expect_true("EP_UNEMP" %in% names(result))
+  expect_true("MP_POV" %in% names(result))
+  expect_true("MP_NOHSDP" %in% names(result))
+  expect_true("MP_UNEMP" %in% names(result))
+
+  # Verify numeric and finite for valid data
+  expect_true(is.numeric(result$EP_POV))
+  expect_true(is.numeric(result$MP_POV))
+  expect_true(all(is.finite(result$EP_POV) | is.na(result$EP_POV)))
+})
+
+# test NDI-PW percent calculations (EP_) ---------------------------------
+
+test_that("dep_process_ndi_pw EP_ columns match baseline values", {
+  result <- suppressWarnings(
+    dep_process_ndi_pw(ndi_pw_data, geography = "county",
+                       year = 2022, survey = "acs5",
+                       keep_components = TRUE, return_percentiles = FALSE)
+  )
+
+  # Verify key columns exist and have expected types
+  expect_true("EP_FAMPOV" %in% names(result))
+  expect_true("EP_UNEMP" %in% names(result))
+  expect_true(is.numeric(result$EP_FAMPOV))
+  expect_true(is.numeric(result$EP_UNEMP))
+
+  # Values should be in valid percent range [0, 100] for valid data
+  expect_true(all(result$EP_FAMPOV >= 0 & result$EP_FAMPOV <= 100, na.rm = TRUE))
+  expect_true(all(result$EP_UNEMP >= 0 & result$EP_UNEMP <= 100, na.rm = TRUE))
+})
+
+# test that no Inf/NaN are produced in sample data -----------------------
+
+test_that("NDI-M produces no Inf or NaN in EP/MP columns for sample data", {
+  result <- suppressWarnings(
+    dep_process_ndi_m(ndi_m_data, geography = "county",
+                      year = 2022, survey = "acs5",
+                      keep_components = TRUE, return_percentiles = FALSE)
+  )
+
+  ep_mp_cols <- grep("^EP_|^MP_", names(result), value = TRUE)
+  for (col in ep_mp_cols) {
+    inf_count <- sum(is.infinite(result[[col]]), na.rm = TRUE)
+    nan_count <- sum(is.nan(result[[col]]), na.rm = TRUE)
+    expect_equal(inf_count, 0, info = paste("Inf found in", col))
+    expect_equal(nan_count, 0, info = paste("NaN found in", col))
+  }
+})
+
+test_that("SVI20 SES produces no Inf in EP/MP columns for sample data", {
+  result <- suppressWarnings(
+    dep_process_svi_ses(svi20_data, style = "svi20", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  ep_mp_cols <- grep("^EP_|^MP_", names(result), value = TRUE)
+  for (col in ep_mp_cols) {
+    inf_count <- sum(is.infinite(result[[col]]), na.rm = TRUE)
+    expect_equal(inf_count, 0, info = paste("Inf found in", col))
+  }
+})
+
+test_that("SVI20 HTT produces no Inf in EP/MP columns for sample data", {
+  result <- suppressWarnings(
+    dep_process_svi_htt(svi20_data, style = "svi20", geography = "county",
+                        year = 2022, survey = "acs5", keep_components = TRUE)
+  )
+
+  ep_mp_cols <- grep("^EP_|^MP_", names(result), value = TRUE)
+  for (col in ep_mp_cols) {
+    inf_count <- sum(is.infinite(result[[col]]), na.rm = TRUE)
+    expect_equal(inf_count, 0, info = paste("Inf found in", col))
+  }
+})

--- a/tests/testthat/test_dep_utils.R
+++ b/tests/testthat/test_dep_utils.R
@@ -77,3 +77,83 @@ test_that("pivot_demos aggregates estimate and moe columns", {
   expect_true("moe" %in% names(result))
   expect_equal(nrow(result), 2)
 })
+
+# test dep_safe_pct ------------------------------------------------
+
+test_that("dep_safe_pct computes correct percentages", {
+  expect_equal(deprivateR:::dep_safe_pct(50, 200), 25)
+  expect_equal(deprivateR:::dep_safe_pct(1, 4), 25)
+  expect_equal(deprivateR:::dep_safe_pct(0, 100), 0)
+})
+
+test_that("dep_safe_pct is vectorized", {
+  result <- deprivateR:::dep_safe_pct(c(10, 20, 30), c(100, 200, 300))
+  expect_equal(result, c(10, 10, 10))
+})
+
+test_that("dep_safe_pct returns NA for zero denominator", {
+  expect_true(is.na(deprivateR:::dep_safe_pct(50, 0)))
+  result <- deprivateR:::dep_safe_pct(c(10, 20), c(0, 100))
+  expect_true(is.na(result[1]))
+  expect_equal(result[2], 20)
+})
+
+test_that("dep_safe_pct returns NA for NA denominator", {
+  expect_true(is.na(deprivateR:::dep_safe_pct(50, NA)))
+})
+
+test_that("dep_safe_pct handles NA numerator", {
+  expect_true(is.na(deprivateR:::dep_safe_pct(NA, 100)))
+})
+
+# test dep_derived_moe ------------------------------------------------
+
+test_that("dep_derived_moe computes correct values for valid inputs", {
+  # Manual calculation: ((sqrt(10^2 - ((50/100)^2 * 8^2))) / 8) * 100
+  # = ((sqrt(100 - (0.25 * 64))) / 8) * 100
+  # = ((sqrt(100 - 16)) / 8) * 100
+  # = ((sqrt(84)) / 8) * 100
+  # = (9.165151 / 8) * 100
+  # = 114.5644
+  result <- deprivateR:::dep_derived_moe(10, 50, 8, 8)
+  expect_equal(result, (sqrt(100 - 16) / 8) * 100, tolerance = 1e-10)
+})
+
+test_that("dep_derived_moe is vectorized", {
+  result <- deprivateR:::dep_derived_moe(
+    estimate_moe = c(10, 20),
+    proportion = c(50, 25),
+    denominator_moe = c(8, 16),
+    denominator = c(8, 16)
+  )
+  expect_length(result, 2)
+  expect_true(all(is.finite(result)))
+})
+
+test_that("dep_derived_moe returns NA for zero denominator", {
+  result <- deprivateR:::dep_derived_moe(10, 50, 8, 0)
+  expect_true(is.na(result))
+})
+
+test_that("dep_derived_moe returns NA for NA denominator", {
+  result <- deprivateR:::dep_derived_moe(10, 50, 8, NA)
+  expect_true(is.na(result))
+})
+
+test_that("dep_derived_moe returns NA for negative radicand", {
+  # radicand = 5^2 - ((90/100)^2 * 10^2) = 25 - 81 = -56
+
+  result <- deprivateR:::dep_derived_moe(5, 90, 10, 10)
+  expect_true(is.na(result))
+})
+
+test_that("dep_derived_moe handles mixed valid/invalid in vector", {
+  result <- deprivateR:::dep_derived_moe(
+    estimate_moe = c(10, 5),
+    proportion = c(50, 90),
+    denominator_moe = c(8, 10),
+    denominator = c(8, 10)
+  )
+  expect_true(is.finite(result[1]))
+  expect_true(is.na(result[2]))  # negative radicand
+})


### PR DESCRIPTION
## Summary

Extract two internal helper functions that centralize repeated percent and derived margin-of-error calculations across all NDI and SVI processing functions. This is Phase 1 of Epic F (#52) — foundational helpers that subsequent refactoring phases depend on.

## Implementation

- **`dep_safe_pct(numerator, denominator)`** — vectorized safe percentage; returns `NA_real_` when denominator is 0 or `NA` (instead of `Inf`/`NaN`)
- **`dep_derived_moe(estimate_moe, proportion, denominator_moe, denominator)`** — Census-standard derived MOE formula `((sqrt(M² - (EP/100)² × DM²)) / DM) × 100`; returns `NA_real_` for negative radicand or zero denominator
- Replaced ~78 hand-written formula instances across `R/dep_process_ndi.R` and `R/dep_process_svi.R`
- Added baseline snapshot tests (124 assertions) capturing exact numeric output before refactoring

## Testing

- All 509 tests pass (17 new helper unit tests + 124 new baseline snapshot tests)
- `R CMD check`: 0 errors, 0 warnings, 0 notes
- Baseline snapshot tests confirm zero numeric drift after replacement
- Edge cases tested: zero denominator, NA denominator, negative radicand, NA numerator, vectorized inputs

## Closes

- Closes #60
- Closes #61

## Notes

- **⚠️ R/ changes require UAT:** Behavior-preserving for all valid inputs. The only edge-case difference: zero denominators now produce `NA_real_` instead of `Inf`/`NaN` (the intended improvement from #61).
- Code review finding (medium): test data setup outside `test_that()` blocks — consistent with existing codebase pattern (see `test_dep_process_svi.R`).
- Phase 1 of the Epic F implementation plan posted on #52.
