### PR TITLE
refactor: Phase 3 structural refactors — SVI dispatcher loop and dep_get_data nesting (#62, #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Refactored SVI dispatcher in `dep_process()` from 4 repetitive if-blocks (~76 lines) to a single loop (~17 lines); no behavior changes (#62)
+- Reduced nesting depth in `dep_get_data()` using early returns and extracted `dep_get_county_tract()`, `dep_territory_fips()`, `dep_build_states()`, and `dep_finalize_output()` internal helpers; max nesting reduced from 4 levels to 2 (#64)
 - Extracted `dep_validate_inputs()` internal helper, consolidating ~90 lines of duplicated input validation from `dep_get_index()` and `dep_calc_index()` into a single reusable function (#59)
 - Extracted `dep_safe_pct()` and `dep_derived_moe()` internal helpers, replacing ~78 hand-written formula instances across NDI and SVI processing functions; zero denominators now produce `NA` instead of `Inf`/`NaN` (#60, #61)
 - Removed manual `@usage` roxygen2 tags from function documentation; usage is now auto-generated from signatures (#40)

--- a/R/dep_get_data.R
+++ b/R/dep_get_data.R
@@ -10,136 +10,119 @@ dep_get_data <- function(geography, varlist, year, survey, state, county,
                          shift_geo, key, debug){
 
   ## pull data based on geography type
-  if (geography == "zcta5"){
-
-    out <- dep_get_zcta5(varlist = varlist, year = year, survey = survey,
+  if (geography == "zcta5") {
+    return(dep_get_zcta5(varlist = varlist, year = year, survey = survey,
                          state = state, county = county, puerto_rico = puerto_rico,
                          zcta = zcta, zcta_geo_method = zcta_geo_method, geometry = geometry,
                          cb = cb, keep_geo_vars = keep_geo_vars,
-                         shift_geo = shift_geo, key = key, debug = debug)
+                         shift_geo = shift_geo, key = key, debug = debug))
+  }
 
-  } else if (geography == "zcta3"){
-
-    out <- dep_get_zcta3(varlist = varlist, year = year, survey = survey,
+  if (geography == "zcta3") {
+    return(dep_get_zcta3(varlist = varlist, year = year, survey = survey,
                          state = state, county = county, puerto_rico = puerto_rico,
                          zcta = zcta, zcta3_method = zcta3_method, geometry = geometry,
-                         shift_geo = shift_geo, key = key, debug = debug)
+                         shift_geo = shift_geo, key = key, debug = debug))
+  }
 
-  } else if (geography %in% c("county", "tract")){
-
-    if (is.null(county) == FALSE){
-
-      ## create vector of unique states
-      states <- unique(substr(county, 1,2))
-
-      ## iterate over unique states and pull data
-      out <- lapply(states, function(states_vec) {
-        dep_get_census(geography = geography, varlist = varlist,
-                       year = year, survey = survey,
-                       state = states_vec, county = county,
-                       geometry = geometry, keep_geo_vars = keep_geo_vars,
-                       key = key, debug = debug)
-      })
-
-      ## combine results
-      out <- do.call(rbind, out)
-
-    } else if (is.null(county) == TRUE){
-
-      if (geography == "county"){
-
-        # pull data
-        out <- dep_get_census(geography = geography, varlist = varlist,
+  ## county/tract geography
+  out <- dep_get_county_tract(geography = geography, varlist = varlist,
                               year = year, survey = survey,
                               state = state, county = county,
-                              geometry = geometry,
-                              keep_geo_vars = keep_geo_vars,
+                              puerto_rico = puerto_rico,
+                              geometry = geometry, keep_geo_vars = keep_geo_vars,
                               key = key, debug = debug)
 
-        # manage territories
-        ## set vector
-        if (puerto_rico == FALSE){
-          territory_vec <- c("60", "66", "69", "72", "78")
-        } else if (puerto_rico == TRUE){
-          territory_vec <- c("60", "66", "69", "78")
-        }
+  ## finalize: split into geo and demo
+  out <- dep_finalize_output(out, varlist = varlist, geometry = geometry,
+                             keep_geo_vars = keep_geo_vars, shift_geo = shift_geo)
 
-        ## exclude
-        out <- subset(out, substr(GEOID, 1,2) %in% territory_vec == FALSE)
+  return(out)
+}
 
-      } else if (geography == "tract"){
+# Helper: retrieve county or tract data with flattened logic
+dep_get_county_tract <- function(geography, varlist, year, survey,
+                                 state, county, puerto_rico,
+                                 geometry, keep_geo_vars, key, debug) {
 
-        # manage states and territories
-        if (is.null(state) == TRUE){
-          if (puerto_rico == FALSE){
-            states <- state.abb
-          } else if (puerto_rico == TRUE){
-            states <- c(state.abb, "PR")
-          }
-        } else if (is.null(state) == FALSE){
-          if (puerto_rico == FALSE){
-            states <- state
-          } else if (puerto_rico == TRUE){
-            states <- c(state, "PR")
-          }
-        }
+  # when county is specified, iterate over unique states in county FIPS
 
-        # pull data
-        out <- lapply(states, function(states_vec) {
-          dep_get_census(geography = geography, varlist = varlist,
-                         year = year, survey = survey,
-                         state = states_vec, county = county,
-                         geometry = geometry, keep_geo_vars = keep_geo_vars,
-                         key = key, debug = debug)
-        })
-
-        ## combine results
-        out <- do.call(rbind, out)
-
-      }
-
-    }
-
+  if (!is.null(county)) {
+    states <- unique(substr(county, 1, 2))
+    out <- lapply(states, function(states_vec) {
+      dep_get_census(geography = geography, varlist = varlist,
+                     year = year, survey = survey,
+                     state = states_vec, county = county,
+                     geometry = geometry, keep_geo_vars = keep_geo_vars,
+                     key = key, debug = debug)
+    })
+    return(do.call(rbind, out))
   }
 
-  ## finalize output
-  if (geography %in% c("zcta3", "zcta5") == FALSE){
+  # county geography without county filter
+  if (geography == "county") {
+    out <- dep_get_census(geography = geography, varlist = varlist,
+                          year = year, survey = survey,
+                          state = state, county = county,
+                          geometry = geometry,
+                          keep_geo_vars = keep_geo_vars,
+                          key = key, debug = debug)
 
-    ## optionally handle geometric data
-    if (geometry == TRUE){
+    territory_vec <- dep_territory_fips(puerto_rico)
+    out <- subset(out, !substr(GEOID, 1, 2) %in% territory_vec)
+    return(out)
+  }
 
-      ## break apart geo and demo data
-      if (keep_geo_vars == TRUE){
-        geo <- subset(out, select = -c(varlist))
-        demo <- data.frame(rep(NA, nrow(out)))
+  # tract geography without county filter
+  states <- dep_build_states(state = state, puerto_rico = puerto_rico)
 
-      } else if (keep_geo_vars == FALSE){
-        geo <- subset(out, select = c(GEOID, NAME))
-        demo <- subset(out, select = -NAME)
-        sf::st_geometry(demo) <- NULL
-      }
+  out <- lapply(states, function(states_vec) {
+    dep_get_census(geography = geography, varlist = varlist,
+                   year = year, survey = survey,
+                   state = states_vec, county = county,
+                   geometry = geometry, keep_geo_vars = keep_geo_vars,
+                   key = key, debug = debug)
+  })
 
-      ## shift geometry
-      if (shift_geo == TRUE){
-        geo <- tigris::shift_geometry(geo, position = "below")
-      }
+  do.call(rbind, out)
+}
 
-    } else if (geometry == FALSE){
+# Helper: territory FIPS codes to exclude
+dep_territory_fips <- function(puerto_rico) {
+  if (puerto_rico) {
+    c("60", "66", "69", "78")
+  } else {
+    c("60", "66", "69", "72", "78")
+  }
+}
+
+# Helper: build state vector for tract iteration
+dep_build_states <- function(state, puerto_rico) {
+  base <- if (is.null(state)) state.abb else state
+  if (puerto_rico) c(base, "PR") else base
+}
+
+# Helper: split raw output into geo/demo list
+dep_finalize_output <- function(out, varlist, geometry, keep_geo_vars, shift_geo) {
+  if (geometry) {
+    if (keep_geo_vars) {
+      geo <- subset(out, select = -c(varlist))
+      demo <- data.frame(rep(NA, nrow(out)))
+    } else {
       geo <- subset(out, select = c(GEOID, NAME))
       demo <- subset(out, select = -NAME)
+      sf::st_geometry(demo) <- NULL
     }
 
-    ## construct output
-    out <- list(
-      geo = geo,
-      demo = demo
-    )
-
+    if (shift_geo) {
+      geo <- tigris::shift_geometry(geo, position = "below")
+    }
+  } else {
+    geo <- subset(out, select = c(GEOID, NAME))
+    demo <- subset(out, select = -NAME)
   }
 
-  ## return output
-  return(out)
-
+  list(geo = geo, demo = demo)
 }
 
 

--- a/R/dep_process.R
+++ b/R/dep_process.R
@@ -55,82 +55,21 @@ dep_process <- function(.data, geography, index, year, survey,
   }
 
   # create svi output
-  ## 2010 SVI style
-  if ("svi10" %in% index == TRUE){
-
-    ## build svi scores
-    svi <- dep_process_svi(demo, style = "svi10",
+  svi_styles <- intersect(c("svi10", "svi14", "svi20", "svi20s"), index)
+  for (style in svi_styles) {
+    svi <- dep_process_svi(demo, style = style,
                            geography = geography, year = year, survey = survey,
                            keep_subscales = keep_subscales,
                            keep_components = keep_components,
                            return_percentiles = return_percentiles,
                            multi_svi = multi_svi, debug = debug)
 
-    ## combine with output
-    out <- merge(x = out, y = svi, by = "GEOID", all.x = TRUE)
-  }
-
-  ## 2014 SVI style
-  if ("svi14" %in% index == TRUE){
-
-    ## build svi scores
-    svi <- dep_process_svi(demo, style = "svi14",
-                           geography = geography, year = year, survey = survey,
-                           keep_subscales = keep_subscales,
-                           keep_components = keep_components,
-                           return_percentiles = return_percentiles,
-                           multi_svi = multi_svi, debug = debug)
-
-    ## optionally limit output to unique cols
-    if (multi_svi == TRUE){
+    # limit to unique columns for second+ SVI style when multi_svi is active
+    if (multi_svi && style != svi_styles[1]) {
       excess_vars <- c("GEOID", setdiff(names(svi), names(out)))
       svi <- subset(svi, select = excess_vars)
     }
 
-    ## combine with output
-    out <- merge(x = out, y = svi, by = "GEOID", all.x = TRUE)
-
-  }
-
-  ## 2020 SVI style
-  if ("svi20" %in% index == TRUE){
-
-    ## build svi scores
-    svi <- dep_process_svi(demo, style = "svi20",
-                           geography = geography, year = year, survey = survey,
-                           keep_subscales = keep_subscales,
-                           keep_components = keep_components,
-                           return_percentiles = return_percentiles,
-                           multi_svi = multi_svi, debug = debug)
-
-    ## optionally limit output to unique cols
-    if (multi_svi == TRUE){
-      excess_vars <- c("GEOID", setdiff(names(svi), names(out)))
-      svi <- subset(svi, select = excess_vars)
-    }
-
-    ## combine with output
-    out <- merge(x = out, y = svi, by = "GEOID", all.x = TRUE)
-  }
-
-  ## 2020 svi style with alternate single parent definition
-  if ("svi20s" %in% index == TRUE){
-
-    ## build svi scores
-    svi <- dep_process_svi(demo, style = "svi20s",
-                           geography = geography, year = year, survey = survey,
-                           keep_subscales = keep_subscales,
-                           keep_components = keep_components,
-                           return_percentiles = return_percentiles,
-                           multi_svi = multi_svi, debug = debug)
-
-    ## optionally limit output to unique cols
-    if (multi_svi == TRUE){
-      excess_vars <- c("GEOID", setdiff(names(svi), names(out)))
-      svi <- subset(svi, select = excess_vars)
-    }
-
-    ## combine with output
     out <- merge(x = out, y = svi, by = "GEOID", all.x = TRUE)
   }
 

--- a/tests/testthat/test_dep_get_data.R
+++ b/tests/testthat/test_dep_get_data.R
@@ -52,6 +52,43 @@ test_that("validate_state handles whitespace in input", {
   expect_equal(validate_state(" 29 ", .msg = FALSE), "29")
 })
 
+# test dep_territory_fips ---------------------------------------------------
+
+test_that("dep_territory_fips excludes PR when puerto_rico is FALSE", {
+  result <- dep_territory_fips(FALSE)
+  expect_true("72" %in% result)
+  expect_equal(length(result), 5)
+})
+
+test_that("dep_territory_fips includes PR when puerto_rico is TRUE", {
+  result <- dep_territory_fips(TRUE)
+  expect_false("72" %in% result)
+  expect_equal(length(result), 4)
+})
+
+# test dep_build_states ---------------------------------------------------
+
+test_that("dep_build_states returns state.abb when state is NULL", {
+  result <- dep_build_states(state = NULL, puerto_rico = FALSE)
+  expect_equal(result, state.abb)
+})
+
+test_that("dep_build_states adds PR when puerto_rico is TRUE", {
+  result <- dep_build_states(state = NULL, puerto_rico = TRUE)
+  expect_true("PR" %in% result)
+  expect_equal(length(result), length(state.abb) + 1)
+})
+
+test_that("dep_build_states respects specific state input", {
+  result <- dep_build_states(state = c("MO", "IL"), puerto_rico = FALSE)
+  expect_equal(result, c("MO", "IL"))
+})
+
+test_that("dep_build_states adds PR to specific state input", {
+  result <- dep_build_states(state = "MO", puerto_rico = TRUE)
+  expect_equal(result, c("MO", "PR"))
+})
+
 # test dep_get_census county subsetting -----------------------------------
 
 test_that("dep_get_census subsets county FIPS to match state", {

--- a/tests/testthat/test_dep_process.R
+++ b/tests/testthat/test_dep_process.R
@@ -149,7 +149,11 @@ test_that("dep_process with output = 'tidy' returns long format", {
 # test multi-SVI dispatcher ------------------------------------------------
 
 test_that("dep_process handles multiple SVI styles with multi_svi = TRUE", {
-  multi_data <- dep_sample_data(index = c("svi10", "svi20"))
+  svi10_raw <- dep_sample_data(index = "svi10")
+  svi20_raw <- dep_sample_data(index = "svi20")
+  # combine columns from both datasets (same rows — Missouri counties)
+  multi_data <- cbind(svi10_raw,
+                      svi20_raw[, setdiff(names(svi20_raw), names(svi10_raw)), drop = FALSE])
 
   result <- dep_process(multi_data, geography = "county",
                         index = c("svi10", "svi20"),

--- a/tests/testthat/test_dep_process.R
+++ b/tests/testthat/test_dep_process.R
@@ -146,6 +146,87 @@ test_that("dep_process with output = 'tidy' returns long format", {
   expect_true("GEOID" %in% names(result))
 })
 
+# test multi-SVI dispatcher ------------------------------------------------
+
+test_that("dep_process handles multiple SVI styles with multi_svi = TRUE", {
+  multi_data <- dep_sample_data(index = c("svi10", "svi20"))
+
+  result <- dep_process(multi_data, geography = "county",
+                        index = c("svi10", "svi20"),
+                        year = 2022, survey = "acs5",
+                        return_percentiles = FALSE, keep_subscales = FALSE,
+                        keep_components = FALSE,
+                        state = NULL, county = NULL, puerto_rico = FALSE,
+                        zcta = NULL, zcta_geo_method = NULL, zcta3_method = NULL,
+                        geometry = FALSE, cb = FALSE, keep_geo_vars = FALSE,
+                        shift_geo = FALSE, key = NULL,
+                        debug = FALSE, input = "user", output = "wide",
+                        label_year = FALSE, multi_svi = TRUE)
+
+  expect_true("GEOID" %in% names(result))
+  # First SVI style columns present (svi10 uses full names)
+  expect_true("SVI_10" %in% names(result))
+  # Second SVI style columns present (svi20 uses postfix)
+  expect_true("SVI_20" %in% names(result))
+  expect_s3_class(result, "tbl_df")
+  # No duplicate GEOID columns
+  expect_equal(sum(names(result) == "GEOID"), 1)
+})
+
+test_that("dep_process routes svi10 correctly", {
+  svi10_data <- dep_sample_data(index = "svi10")
+
+  result <- dep_process(svi10_data, geography = "county", index = "svi10",
+                        year = 2022, survey = "acs5",
+                        return_percentiles = FALSE, keep_subscales = FALSE,
+                        keep_components = FALSE,
+                        state = NULL, county = NULL, puerto_rico = FALSE,
+                        zcta = NULL, zcta_geo_method = NULL, zcta3_method = NULL,
+                        geometry = FALSE, cb = FALSE, keep_geo_vars = FALSE,
+                        shift_geo = FALSE, key = NULL,
+                        debug = FALSE, input = "user", output = "wide",
+                        label_year = FALSE, multi_svi = FALSE)
+
+  expect_true("SVI" %in% names(result))
+  expect_true(is.numeric(result$SVI))
+})
+
+test_that("dep_process routes svi14 correctly", {
+  svi14_data <- dep_sample_data(index = "svi14")
+
+  result <- dep_process(svi14_data, geography = "county", index = "svi14",
+                        year = 2022, survey = "acs5",
+                        return_percentiles = FALSE, keep_subscales = FALSE,
+                        keep_components = FALSE,
+                        state = NULL, county = NULL, puerto_rico = FALSE,
+                        zcta = NULL, zcta_geo_method = NULL, zcta3_method = NULL,
+                        geometry = FALSE, cb = FALSE, keep_geo_vars = FALSE,
+                        shift_geo = FALSE, key = NULL,
+                        debug = FALSE, input = "user", output = "wide",
+                        label_year = FALSE, multi_svi = FALSE)
+
+  expect_true("SVI" %in% names(result))
+  expect_true(is.numeric(result$SVI))
+})
+
+test_that("dep_process routes svi20s correctly", {
+  svi20s_data <- dep_sample_data(index = "svi20s")
+
+  result <- dep_process(svi20s_data, geography = "county", index = "svi20s",
+                        year = 2022, survey = "acs5",
+                        return_percentiles = FALSE, keep_subscales = FALSE,
+                        keep_components = FALSE,
+                        state = NULL, county = NULL, puerto_rico = FALSE,
+                        zcta = NULL, zcta_geo_method = NULL, zcta3_method = NULL,
+                        geometry = FALSE, cb = FALSE, keep_geo_vars = FALSE,
+                        shift_geo = FALSE, key = NULL,
+                        debug = FALSE, input = "user", output = "wide",
+                        label_year = FALSE, multi_svi = FALSE)
+
+  expect_true("SVI" %in% names(result))
+  expect_true(is.numeric(result$SVI))
+})
+
 # test multiple indices ---------------------------------------------------
 
 test_that("dep_process handles multiple indices via dep_calc_index", {


### PR DESCRIPTION
## Summary

Phase 3 of Epic F ([#52](https://github.com/pfizer-opensource/deprivateR/issues/52)): structural refactors to improve code maintainability.

### Changes

**#62 — SVI dispatcher loop:**
- Replaced 4 repetitive if-blocks (~76 lines) in `dep_process()` with a single `for` loop over `intersect(c("svi10", "svi14", "svi20", "svi20s"), index)` (~17 lines)
- Canonical order preserved: `svi10` is always processed first (without column filtering), matching original behavior exactly
- No user-facing behavior changes

**#64 — dep_get_data nesting reduction:**
- Used early returns to eliminate nested `else if` chains for zcta5/zcta3 geography types
- Extracted `dep_get_county_tract()` helper with flat guard-clause structure
- Extracted `dep_territory_fips()` and `dep_build_states()` helpers to deduplicate territory/state logic
- Extracted `dep_finalize_output()` helper for geo/demo splitting
- Maximum nesting depth reduced from 4 levels to 2

### Testing

- Added safety-net tests for multi_svi dispatcher path (multi-style with `multi_svi = TRUE`)
- Added tests for each individual SVI style (svi10, svi14, svi20s) through the dispatcher
- Added unit tests for `dep_territory_fips()` and `dep_build_states()` helpers

Closes #62, closes #64