### PR TITLE
refactor: adopt idiomatic logical comparisons (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Adopted idiomatic logical comparisons across 12 source files — removed all `== TRUE`/`== FALSE` anti-patterns (#65)
 - Refactored SVI dispatcher in `dep_process()` from 4 repetitive if-blocks (~76 lines) to a single loop (~17 lines); no behavior changes (#62)
 - Reduced nesting depth in `dep_get_data()` using early returns and extracted `dep_get_county_tract()`, `dep_territory_fips()`, `dep_build_states()`, and `dep_finalize_output()` internal helpers; max nesting reduced from 4 levels to 2 (#64)
 - Extracted `dep_validate_inputs()` internal helper, consolidating ~90 lines of duplicated input validation from `dep_get_index()` and `dep_calc_index()` into a single reusable function (#59)

--- a/R/dep_build_varlist.R
+++ b/R/dep_build_varlist.R
@@ -31,63 +31,63 @@
 dep_build_varlist <- function(geography, index, year, survey = "acs5", output = "vector"){
 
   # check inputs
-  if (missing(geography) == TRUE) {
+  if (missing(geography)) {
     cli::cli_abort(c(
       "A {.arg geography} value must be provided.",
       "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
     ))
   }
 
-  if (geography %in% c("county", "zcta3", "zcta5", "tract") == FALSE){
+  if (!(geography %in% c("county", "zcta3", "zcta5", "tract"))){
     cli::cli_abort(c(
       "Invalid {.arg geography} provided: {.val {geography}}.",
       "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
     ))
   }
 
-  if (missing(index) == TRUE){
+  if (missing(index)){
     cli::cli_abort(c(
       "A {.arg index} value must be provided.",
       "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
     ))
   }
 
-  if (all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE){
+  if (!all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s"))){
     cli::cli_abort(c(
       "Invalid {.arg index} provided: {.val {index}}.",
       "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
     ))
   }
 
-  if (missing(year) == TRUE){
+  if (missing(year)){
     cli::cli_abort(c(
       "A {.arg year} value must be provided.",
       "i" = "Choose a numeric value between {.val 2010} and {.val 2022}."
     ))
   }
 
-  if (is.numeric(year) == FALSE | (min(year) < 2010 | max(year) > 2022)){
+  if (!is.numeric(year) | (min(year) < 2010 | max(year) > 2022)){
     cli::cli_abort(c(
       "Invalid {.arg year} provided: {.val {year}}.",
       "i" = "Provide a numeric value between {.val 2010} and {.val 2022}."
     ))
   }
 
-  if (any(index %in% c("svi14", "svi20")) == TRUE & min(year) < 2012){
+  if (any(index %in% c("svi14", "svi20")) & min(year) < 2012){
     cli::cli_abort(c(
       "Invalid {.arg year} provided for {.arg index}: {.val {year}}.",
       "i" = "{.val svi14} and {.val svi20} can be calculated from {.val 2012} onward. Use {.val svi10} for {.val 2010} or {.val 2011}."
     ))
   }
 
-  if (any(index == "svi20s") == TRUE & min(year) < 2019){
+  if (any(index == "svi20s") & min(year) < 2019){
     cli::cli_abort(c(
       "Invalid {.arg year} provided for {.arg index}: {.val {year}}.",
       "i" = "{.val svi20s} can only be calculated from {.val 2019} onward."
     ))
   }
 
-  if (survey %in% c("acs1", "acs3", "acs5") == FALSE){
+  if (!(survey %in% c("acs1", "acs3", "acs5"))){
     cli::cli_abort(c(
       "Invalid {.arg survey} provided: {.val {survey}}.",
       "i" = "Choose one of: {.val acs1}, {.val acs3}, or {.val acs5}."
@@ -101,7 +101,7 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
     ))
   }
 
-  if (output %in% c("vector", "tibble") == FALSE){
+  if (!(output %in% c("vector", "tibble"))){
     cli::cli_abort(c(
       "Invalid {.arg output} provided: {.val {output}}.",
       "i" = "Choose one of: {.val vector} or {.val tibble}."
@@ -109,7 +109,7 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
   }
 
   ## gini
-  if ("gini" %in% index == TRUE){
+  if ("gini" %in% index){
     gini_vars <- request_vars$gini10
   } else {
     gini_vars <- NULL
@@ -117,10 +117,10 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
 
   ## svi
   ### 2010 svi style
-  if ("svi10" %in% index == TRUE){
-    if (year %in% c(2010:2014) == TRUE){
+  if ("svi10" %in% index){
+    if (year %in% c(2010:2014)){
       svi10_vars <- unlist(request_vars$svi10_10)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       svi10_vars <- unlist(request_vars$svi10_15)
     } else if (year > 2016){
       svi10_vars <- unlist(request_vars$svi10_17)
@@ -130,10 +130,10 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
   }
 
   ### 2014 svi style
-  if ("svi14" %in% index == TRUE){
-    if (year %in% c(2012:2014) == TRUE){
+  if ("svi14" %in% index){
+    if (year %in% c(2012:2014)){
       svi14_vars <- unlist(request_vars$svi14_12)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       svi14_vars <- unlist(request_vars$svi14_15)
     } else if (year > 2016){
       svi14_vars <- unlist(request_vars$svi14_17)
@@ -143,12 +143,12 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
   }
 
   ### 2020 svi style
-  if ("svi20" %in% index == TRUE){
+  if ("svi20" %in% index){
     if (year == 2012){
       svi20_vars <- unlist(request_vars$svi20_12)
     } else if (year %in% c(2013, 2014)){
       svi20_vars <- unlist(request_vars$svi20_13)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       svi20_vars <- unlist(request_vars$svi20_15)
     } else if (year > 2016){
       svi20_vars <- unlist(request_vars$svi20_17)
@@ -158,28 +158,28 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
   }
 
   ### 2020 svi style with alt definition of single parent households
-  if ("svi20s" %in% index == TRUE){
+  if ("svi20s" %in% index){
     svi20s_vars <- unlist(request_vars$svi20s_19)
   } else {
     svi20s_vars <- NULL
   }
 
   ## adi
-  if ("adi" %in% index == TRUE){
+  if ("adi" %in% index){
     adi_vars <- build_adi_varlist(geography, year = year, survey = survey)
   } else {
     adi_vars <- NULL
   }
 
   ## ndi, messer
-  if ("ndi_m" %in% index == TRUE){
+  if ("ndi_m" %in% index){
     ndi_m_vars <- request_vars$ndi_m
   } else {
     ndi_m_vars <- NULL
   }
 
   ## ndi, powell-wiley
-  if ("ndi_pw" %in% index == TRUE){
+  if ("ndi_pw" %in% index){
     ndi_pw_vars <- request_vars$ndi_pw
   } else {
     ndi_pw_vars <- NULL
@@ -199,7 +199,7 @@ dep_build_varlist <- function(geography, index, year, survey = "acs5", output = 
     )
 
     #### download variable defs
-    if (index %in% c("adi", "gini") == TRUE){
+    if (index %in% c("adi", "gini")){
       vars <- tidycensus::load_variables(
         year = year,
         dataset = survey
@@ -326,43 +326,43 @@ dep_expand_varlist <- function(geography, index, year, survey,
 
   } else if (index == "svi10, msl all") {
 
-    if (year %in% c(2010:2014) == TRUE){
+    if (year %in% c(2010:2014)){
       out <- c(request_vars$svi10_10$msl_vars, request_vars$svi10_10$eng_vars)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       out <- c(request_vars$svi10_15$msl_vars, request_vars$svi10_15$eng_vars)
-    } else if (year %in% c(2017:2022) == TRUE){
+    } else if (year %in% c(2017:2022)){
       out <- c(request_vars$svi10_17$msl_vars, request_vars$svi10_17$eng_vars)
     }
 
   } else if (index == "svi14, msl all") {
 
-    if (year %in% c(2012:2014) == TRUE){
+    if (year %in% c(2012:2014)){
       out <- c(request_vars$svi14_12$msl_vars, request_vars$svi14_12$eng_vars)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       out <- c(request_vars$svi14_15$msl_vars, request_vars$svi14_15$eng_vars)
-    } else if (year %in% c(2017:2022) == TRUE){
+    } else if (year %in% c(2017:2022)){
       out <- c(request_vars$svi14_17$msl_vars, request_vars$svi14_17$eng_vars)
     }
 
   } else if (index == "svi10, hhd all") {
 
-    if (year %in% c(2010:2014) == TRUE){
+    if (year %in% c(2010:2014)){
       out <- c(request_vars$svi10_10$hhd_vars, request_vars$svi10_10$age_lt18_vars,
                request_vars$svi10_10$age_gt64_vars)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       out <- c(request_vars$svi10_15$hhd_vars, request_vars$svi10_15$age_lt18_vars,
                request_vars$svi10_15$age_gt64_vars)
     }
 
   } else if (index == "svi14, hhd all") {
 
-    if (year %in% c(2012:2014) == TRUE){
+    if (year %in% c(2012:2014)){
       out <- c(request_vars$svi14_12$hhd_vars, request_vars$svi14_12$age_lt18_vars,
                request_vars$svi14_12$age_gt64_vars, request_vars$svi14_12$dis_vars)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       out <- c(request_vars$svi14_15$hhd_vars, request_vars$svi14_15$age_lt18_vars,
                request_vars$svi14_15$age_gt64_vars, request_vars$svi14_15$dis_vars)
-    } else if (year %in% c(2017:2022) == TRUE){
+    } else if (year %in% c(2017:2022)){
       out <- c(request_vars$svi14_17$hhd_vars, request_vars$svi14_17$dis_vars)
     }
 
@@ -372,15 +372,15 @@ dep_expand_varlist <- function(geography, index, year, survey,
       out <- c(request_vars$svi20_12$hhd_vars, request_vars$svi20_12$age_lt18_vars,
                request_vars$svi20_12$age_gt64_vars, request_vars$svi20_12$dis_vars,
                request_vars$svi20_12$eng_vars)
-    } else if (year %in% c(2013, 2014) == TRUE){
+    } else if (year %in% c(2013, 2014)){
       out <- c(request_vars$svi20_13$hhd_vars, request_vars$svi20_13$age_lt18_vars,
                request_vars$svi20_13$age_gt64_vars, request_vars$svi20_13$dis_vars,
                request_vars$svi20_13$eng_vars)
-    } else if (year %in% c(2015, 2016) == TRUE){
+    } else if (year %in% c(2015, 2016)){
       out <- c(request_vars$svi20_15$hhd_vars, request_vars$svi20_15$age_lt18_vars,
                request_vars$svi20_15$age_gt64_vars, request_vars$svi20_15$dis_vars,
                request_vars$svi20_15$eng_vars)
-    } else if (year %in% c(2017:2022) == TRUE){
+    } else if (year %in% c(2017:2022)){
       out <- c(request_vars$svi20_17$hhd_vars, request_vars$svi20_17$dis_vars,
                request_vars$svi20_17$eng_vars)
     }
@@ -401,7 +401,7 @@ dep_expand_varlist <- function(geography, index, year, survey,
 
     if (year == 2012){
       out <- c(request_vars$svi20_12$ses_vars, request_vars$svi20_12$edu_vars)
-    } else if (year %in% c(2013, 2014) == TRUE){
+    } else if (year %in% c(2013, 2014)){
       out <- c(request_vars$svi20_13$ses_vars, request_vars$svi20_13$edu_vars)
     }
 
@@ -418,27 +418,27 @@ dep_expand_varlist <- function(geography, index, year, survey,
                           "svi14, dis", "svi20, dis", "svi20s, dis",
                           "svi10, msl", "svi14, msl", "svi20, msl", "svi20s, msl",
                           "svi10, eng", "svi14, eng", "svi20, eng", "svi20s, eng",
-                          "svi10, htt", "svi14, htt", "svi20, htt", "svi20s, htt") == TRUE){
+                          "svi10, htt", "svi14, htt", "svi20, htt", "svi20s, htt")){
 
     req <- paste0(.dep_str_word(index, 2),"_vars")
 
     if (.dep_str_word(index, 1) == "svi10,"){
 
-      if (year %in% c(2010:2014) == TRUE){
+      if (year %in% c(2010:2014)){
         out <- request_vars$svi10_10[[req]]
-      } else if (year %in% c(2015, 2016) == TRUE){
+      } else if (year %in% c(2015, 2016)){
         out <- request_vars$svi10_15[[req]]
-      } else if (year %in% c(2017:2022) == TRUE){
+      } else if (year %in% c(2017:2022)){
         out <- request_vars$svi10_17[[req]]
       }
 
     } else if (.dep_str_word(index, 1) == "svi14,"){
 
-      if (year %in% c(2012:2014) == TRUE){
+      if (year %in% c(2012:2014)){
         out <- request_vars$svi14_12[[req]]
-      } else if (year %in% c(2015, 2016) == TRUE){
+      } else if (year %in% c(2015, 2016)){
         out <- request_vars$svi14_15[[req]]
-      } else if (year %in% c(2017:2022) == TRUE){
+      } else if (year %in% c(2017:2022)){
         out <- request_vars$svi14_17[[req]]
       }
 
@@ -446,11 +446,11 @@ dep_expand_varlist <- function(geography, index, year, survey,
 
       if (year == 2012){
         out <- request_vars$svi20_12[[req]]
-      } else if (year %in% c(2013, 2014) == TRUE){
+      } else if (year %in% c(2013, 2014)){
         out <- request_vars$svi20_13[[req]]
-      } else if (year %in% c(2015, 2016) == TRUE){
+      } else if (year %in% c(2015, 2016)){
         out <- request_vars$svi20_15[[req]]
-      } else if (year %in% c(2017:2022) == TRUE){
+      } else if (year %in% c(2017:2022)){
         out <- request_vars$svi20_17[[req]]
       }
     } else if (.dep_str_word(index, 1) == "svi20s,"){
@@ -459,11 +459,11 @@ dep_expand_varlist <- function(geography, index, year, survey,
   }
 
   # expand and combine
-  if (estimates_only == FALSE & moe_only == FALSE){
+  if (!estimates_only & !moe_only){
     out <- sort(c(paste0(out, "E"), paste0(out, "M")))
-  } else if (estimates_only == TRUE & moe_only == FALSE){
+  } else if (estimates_only & !moe_only){
     out <- sort(paste0(out, "E"))
-  } else if (estimates_only == FALSE & moe_only == TRUE){
+  } else if (!estimates_only & moe_only){
     out <- sort(paste0(out, "M"))
   }
 
@@ -487,8 +487,8 @@ dep_zcta3_varlist <- function(varlist){
 
   ## create output
   out <- list(
-    extensive = varlist[varlist %in% intensive_vars == FALSE],
-    intensive = varlist[varlist %in% intensive_vars == TRUE]
+    extensive = varlist[!(varlist %in% intensive_vars)],
+    intensive = varlist[varlist %in% intensive_vars]
   )
 
   ## return output

--- a/R/dep_calc_index.R
+++ b/R/dep_calc_index.R
@@ -113,7 +113,7 @@ dep_calc_index <- function(.data, geography, index, year, survey = "acs5",
   }
 
   ## test variable names
-  if (all(var_expected %in% names(.data)) == FALSE){
+  if (!all(var_expected %in% names(.data))){
     cli::cli_abort(c(
       "Variables necessary for the given year(s) and index/indices are missing.",
       "i" = "Please double check your input data."
@@ -148,22 +148,22 @@ dep_calc_index <- function(.data, geography, index, year, survey = "acs5",
 
   # re-construct output
   ## remove name if present
-  if ("NAME" %in% names(.data) == TRUE){
-    out_names <- names(out)[names(out) %in% c("NAME") == FALSE]
+  if ("NAME" %in% names(.data)){
+    out_names <- names(out)[!(names(out) %in% c("NAME"))]
     out <- subset(out, select = out_names)
   }
 
   ## check for variable conflicts
   if (length(year) > 1){
-    out_names <- names(out)[names(out) %in% c("GEOID", "YEAR") == FALSE]
+    out_names <- names(out)[!(names(out) %in% c("GEOID", "YEAR"))]
   } else if (length(year) == 1){
-    out_names <- names(out)[names(out) %in% c("GEOID") == FALSE]
+    out_names <- names(out)[!(names(out) %in% c("GEOID"))]
   }
 
   ## throw warning
-  if (any(out_names %in% names(.data)) == TRUE){
+  if (any(out_names %in% names(.data))){
     cli::cli_warn("Variable conflicts present between input data and deprivation output. Only output returned.")
-  } else if (any(out_names %in% names(.data)) == FALSE){
+  } else if (!any(out_names %in% names(.data))){
     if (length(year) > 1){
       out <- merge(x = .data, y = out, by = c("GEOID", "YEAR"), all.x = TRUE)
     } else if (length(year) == 1){

--- a/R/dep_get_data.R
+++ b/R/dep_get_data.R
@@ -150,20 +150,20 @@ dep_get_zcta5 <- function(varlist, year, survey, state, county,
   }
 
   ## optionally filter based on zcta
-  if (is.null(zcta) == FALSE){
-    demo <- subset(demo, GEOID %in% zcta == TRUE)
+  if (!is.null(zcta)){
+    demo <- subset(demo, GEOID %in% zcta)
   }
 
   ## manage territories
   ### set territory vector
-  if (puerto_rico == FALSE){
+  if (!puerto_rico){
     territory_vec <- c("006", "007", "008", "009", "969")
-  } else if (puerto_rico == TRUE){
+  } else if (puerto_rico){
     territory_vec <- c("008", "969")
   }
 
   ### all territories not including American Samoa
-  demo <- subset(demo, substr(GEOID, 1,3) %in% territory_vec == FALSE)
+  demo <- subset(demo, !(substr(GEOID, 1,3) %in% territory_vec))
 
   ### American Samoa
   demo <- subset(demo, GEOID != "96799")
@@ -176,7 +176,7 @@ dep_get_zcta5 <- function(varlist, year, survey, state, county,
   }
 
   ## optionally add geometry
-  if (geometry == TRUE){
+  if (geometry){
 
     ## set return
     # if (keep_geo_vars == TRUE){
@@ -188,9 +188,9 @@ dep_get_zcta5 <- function(varlist, year, survey, state, county,
     return_type <- "id"
 
     ## set PR flag
-    if (puerto_rico == FALSE){
+    if (!puerto_rico){
       pr <- NULL
-    } else if (puerto_rico == TRUE){
+    } else if (puerto_rico){
       pr <- "PR"
     }
 
@@ -207,11 +207,11 @@ dep_get_zcta5 <- function(varlist, year, survey, state, county,
                                    shift_geo = shift_geo)
 
     ## optionally filter based on zcta
-    if (is.null(zcta) == FALSE){
-      geo <- subset(geo, GEOID %in% zcta == TRUE)
+    if (!is.null(zcta)){
+      geo <- subset(geo, GEOID %in% zcta)
     }
 
-  } else if (geometry == FALSE){
+  } else if (!geometry){
     geo <- dplyr::as_tibble(data.frame(GEOID = demo$GEOID))
   }
 
@@ -249,20 +249,20 @@ dep_get_zcta3 <- function(varlist, year, survey, state, county,
   }
 
   ## optionally filter based on zcta
-  if (is.null(zcta) == FALSE){
-    demo <- subset(demo, GEOID %in% zcta == TRUE)
+  if (!is.null(zcta)){
+    demo <- subset(demo, GEOID %in% zcta)
   }
 
   ## manage territories
   ### set territory vector
-  if (puerto_rico == FALSE){
+  if (!puerto_rico){
     territory_vec <- c("006", "007", "008", "009", "969")
-  } else if (puerto_rico == TRUE){
+  } else if (puerto_rico){
     territory_vec <- c("008", "969")
   }
 
   ### all territories not including American Samoa
-  demo <- subset(demo, substr(GEOID, 1,3) %in% territory_vec == FALSE)
+  demo <- subset(demo, !(substr(GEOID, 1,3) %in% territory_vec))
 
   ### American Samoa
   demo <- subset(demo, GEOID != "96799")
@@ -303,12 +303,12 @@ dep_get_zcta3 <- function(varlist, year, survey, state, county,
   }
 
   ## optionally add geometry
-  if (geometry == TRUE){
+  if (geometry){
 
     ## set PR flag
-    if (puerto_rico == FALSE){
+    if (!puerto_rico){
       pr <- NULL
-    } else if (puerto_rico == TRUE){
+    } else if (puerto_rico){
       pr <- "PR"
     }
 
@@ -324,11 +324,11 @@ dep_get_zcta3 <- function(varlist, year, survey, state, county,
     names(demo)[names(demo) == "ZCTA3"] <- "GEOID"
 
     ## optionally filter based on zcta
-    if (is.null(zcta) == FALSE){
-      geo <- subset(geo, GEOID %in% zcta == TRUE)
+    if (!is.null(zcta)){
+      geo <- subset(geo, GEOID %in% zcta)
     }
 
-  } else if (geometry == FALSE){
+  } else if (!geometry){
     geo <- dplyr::as_tibble(data.frame(GEOID = demo$GEOID))
   }
 
@@ -348,7 +348,7 @@ dep_get_census <- function(geography, varlist, year, survey, state, county,
                            shift_geo, key, debug){
 
   ## subset county to only counties that match state fips
-  if (is.null(county) == FALSE){
+  if (!is.null(county)){
 
     ## isolate state
     county <- county[substr(county, 1, 2) == state]

--- a/R/dep_get_index.R
+++ b/R/dep_get_index.R
@@ -174,11 +174,11 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
     valid_output = c("tidy", "wide", "sf")
   )
 
-  if (is.null(state) == FALSE){
+  if (!is.null(state)){
     state <- unlist(sapply(state, validate_state, USE.NAMES=FALSE))
   }
 
-  if (any(state %in% c("AS", "GU", "MP", "PR", "VI")) == TRUE){
+  if (any(state %in% c("AS", "GU", "MP", "PR", "VI"))){
     cli::cli_abort(c(
       "Territories cannot be specified using the {.arg state} argument.",
       "i" = "Use the {.arg puerto_rico} argument for Puerto Rico.",
@@ -186,22 +186,22 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
     ))
   }
 
-  if (is.null(county) == FALSE & is.null(state) == FALSE){
+  if (!is.null(county) & !is.null(state)){
     cli::cli_abort("Please choose values for either {.arg state} or {.arg county} but not both.")
   }
 
-  if (is.logical(puerto_rico) == FALSE){
+  if (!is.logical(puerto_rico)){
     cli::cli_abort("Please provide a logical scalar for {.arg puerto_rico}.")
   }
 
   ## need to check for zcta3_method
 
-  if (geography != "zcta5" & is.null(zcta) == FALSE){
+  if (geography != "zcta5" & !is.null(zcta)){
     cli::cli_warn("The {.arg zcta} argument was ignored because the geography requested is not {.val zcta5}.")
-  } else if (geography == "zcta5" & is.null(zcta) == FALSE){
+  } else if (geography == "zcta5" & !is.null(zcta)){
     valid <- zippeR::zi_validate(zcta, style = geography)
 
-    if (valid == FALSE){
+    if (!valid){
       cli::cli_abort(c(
         "ZCTA data passed to the {.arg zcta} argument are invalid.",
         "i" = "Use {.fn zippeR::zi_validate} with {.code verbose = TRUE} to investigate further.",
@@ -210,7 +210,7 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
     }
   }
 
-  if (is.logical(zcta_cb) == FALSE){
+  if (!is.logical(zcta_cb)){
     cli::cli_abort("Please provide a logical scalar for {.arg zcta_cb}.")
   }
 
@@ -219,7 +219,7 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
   # }
   keep_geo_vars <- FALSE
 
-  if (is.logical(shift_geo) == FALSE){
+  if (!is.logical(shift_geo)){
     cli::cli_abort("Please provide a logical scalar for {.arg shift_geo}.")
   }
 
@@ -264,9 +264,9 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
   out <- do.call(rbind, out)
 
   ## re-order results
-  if (label_year == TRUE){
+  if (label_year){
     out <- out[order(out$GEOID, out$YEAR), ]
-  } else if (label_year == FALSE){
+  } else if (!label_year){
     out <- out[order(out$GEOID), ]
   }
 

--- a/R/dep_map_breaks.R
+++ b/R/dep_map_breaks.R
@@ -62,20 +62,20 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
                            sig_digits = 2, return = "col", show_warnings = TRUE){
 
   # check return
-  if (return %in% c("col", "breaks") == FALSE){
+  if (!(return %in% c("col", "breaks"))){
     cli::cli_abort("{.arg return} only accepts {.val col} or {.val breaks}.")
   }
 
   # check for correct combination of parameters
-  if (missing(breaks) == FALSE & return == "breaks"){
+  if (!missing(breaks) & return == "breaks"){
     cli::cli_abort(c("Returning breaks is only possible when {.arg breaks} is not supplied.", "i" = "Omit {.arg breaks} or set {.arg return} to {.val col}."))
   }
 
-  if ((missing(classes) == TRUE | missing(style) == TRUE) & missing(breaks) == TRUE){
+  if ((missing(classes) | missing(style)) & missing(breaks)){
     cli::cli_abort(c("Supply values for both {.arg classes} and {.arg style}, or supply {.arg breaks}.", "i" = "Use {.arg classes} with {.arg style} to compute breaks, or provide {.arg breaks} directly."))
   }
 
-  if (return == "col" & missing(new_var) == TRUE){
+  if (return == "col" & missing(new_var)){
     cli::cli_abort(c("A name for {.arg new_var} must be supplied when {.arg return} is {.val col}.", "i" = "Provide {.arg new_var} or set {.arg return} to {.val breaks}."))
   }
 
@@ -102,32 +102,32 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
   }
 
   # check that source variable exists and is numeric
-  if (refQ %in% names(.data) == FALSE){
+  if (!(refQ %in% names(.data))){
     cli::cli_abort("The variable supplied for {.arg var} cannot be found in {.arg .data}.")
   }
 
-  if (class(.data[[refQ]]) %in% c("numeric", "integer") == FALSE){
+  if (!(class(.data[[refQ]]) %in% c("numeric", "integer"))){
     cli::cli_abort("The variable supplied for {.arg var} must be numeric or integer.")
   }
 
   # check other arguments
-  if (missing(classes) == FALSE){
-    if (class(classes) %in% c("numeric", "integer") == FALSE){
+  if (!missing(classes)){
+    if (!(class(classes) %in% c("numeric", "integer"))){
       cli::cli_abort("The value supplied for {.arg classes} must be numeric or integer.")
     }
   }
 
-  if (missing(style) == FALSE){
+  if (!missing(style)){
     styles <- c("fixed", "sd", "equal", "pretty", "quantile", "kmeans", "hclust",
                 "bclust", "fisher", "jenks", "dpih", "headtails", "maximum", "box")
 
-    if (style %in% styles == FALSE){
+    if (!(style %in% styles)){
       cli::cli_abort(c("{.arg style} is not supported by classInt::classIntervals().", "i" = "Use one of: {.val fixed}, {.val sd}, {.val equal}, {.val pretty}, {.val quantile}, {.val kmeans}, {.val hclust}, {.val bclust}, {.val fisher}, {.val jenks}, {.val dpih}, {.val headtails}, {.val maximum}, or {.val box}."))
     }
   }
 
-  if (missing(breaks) == FALSE){
-    if (class(breaks) %in% c("numeric", "integer") == FALSE){
+  if (!missing(breaks)){
+    if (!(class(breaks) %in% c("numeric", "integer"))){
       cli::cli_abort("The vector supplied for {.arg breaks} must be numeric or integer.")
     }
 
@@ -136,22 +136,22 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
     }
   }
 
-  if (class(sig_digits) %in% c("numeric", "integer") == FALSE){
+  if (!(class(sig_digits) %in% c("numeric", "integer"))){
     cli::cli_abort("The value supplied for {.arg sig_digits} must be numeric or integer.")
   }
 
-  if (is.logical(show_warnings) == FALSE){
+  if (!is.logical(show_warnings)){
     cli::cli_abort(c("The value supplied for {.arg show_warnings} must be logical.", "i" = "Use either {.val TRUE} or {.val FALSE}."))
   }
 
   # create breaks object, rounded to specified significant digits
   ## create breaks_values
-  if (missing(breaks) == TRUE){
+  if (missing(breaks)){
 
-    if (show_warnings == TRUE){
+    if (show_warnings){
       breaks_values <- classInt::classIntervals(.data[[refQ]], n = classes,
                                                 style = style)
-    } else if (show_warnings == FALSE){
+    } else if (!show_warnings){
       breaks_values <- suppressWarnings(classInt::classIntervals(.data[[refQ]],
                                                                  n = classes,
                                                                  style = style))
@@ -159,7 +159,7 @@ dep_map_breaks <- function(.data, var, new_var, classes, style, breaks,
 
     breaks_values <- breaks_values$brks
 
-  } else if (missing(breaks) == FALSE){
+  } else if (!missing(breaks)){
     breaks_values <- breaks
   }
 

--- a/R/dep_process.R
+++ b/R/dep_process.R
@@ -42,15 +42,15 @@ dep_process <- function(.data, geography, index, year, survey,
   }
 
   # optionally add year
-  if (label_year == TRUE){
+  if (label_year){
     geo$YEAR <- year
   }
 
   # create gini output
-  if ("gini" %in% index == TRUE){
+  if ("gini" %in% index){
     out <- dep_process_gini(demo, geography = geography, year = year, survey = survey)
     out <- merge(x = geo, y = out, by = "GEOID", all.x = TRUE)
-  } else if ("gini" %in% index == FALSE){
+  } else if (!("gini" %in% index)){
     out <- geo
   }
 
@@ -74,7 +74,7 @@ dep_process <- function(.data, geography, index, year, survey,
   }
 
   # create adi output
-  if ("adi" %in% index == TRUE){
+  if ("adi" %in% index){
     adi <- dep_process_adi(demo, geography = geography, year = year, survey = survey,
                            keep_subscales = keep_subscales,
                            keep_components = keep_components,
@@ -83,7 +83,7 @@ dep_process <- function(.data, geography, index, year, survey,
   }
 
   # create ndi output
-  if ("ndi_m" %in% index == TRUE){
+  if ("ndi_m" %in% index){
     ndi_m <- dep_process_ndi_m(demo, geography = geography, year = year, survey = survey,
                                keep_components = keep_components,
                                return_percentiles = return_percentiles)
@@ -91,7 +91,7 @@ dep_process <- function(.data, geography, index, year, survey,
     out <- merge(x = out, y = ndi_m, by = "GEOID", all.x = TRUE)
   }
 
-  if ("ndi_pw" %in% index == TRUE){
+  if ("ndi_pw" %in% index){
     ndi_pw <- dep_process_ndi_pw(demo, geography = geography, year = year, survey = survey,
                                  keep_components = keep_components,
                                  return_percentiles = return_percentiles)
@@ -105,7 +105,7 @@ dep_process <- function(.data, geography, index, year, survey,
 
   } else if (output == "tidy"){
 
-    cols <- names(out)[names(out) %in% c("GEOID", "NAME") == FALSE]
+    cols <- names(out)[!(names(out) %in% c("GEOID", "NAME"))]
     out <- tidyr::pivot_longer(out, cols = tidyr::all_of(cols), names_to = "index",
                                values_to = "estimate")
 

--- a/R/dep_process_adi.R
+++ b/R/dep_process_adi.R
@@ -25,24 +25,24 @@ dep_process_adi <- function(.data, geography, year, survey,
   .data <- subset(.data, select = -B11005_001)
 
   ## prep output
-  if (return_percentiles == TRUE){
+  if (return_percentiles){
     .data$ADI <- dep_percent_rank(.data$ADI)
     .data$ADI <- .data$ADI*100
   }
 
-  if (keep_subscales == FALSE){
+  if (!keep_subscales){
 
     .data <- subset(.data, select = -c(Financial_Strength,
                                        Economic_Hardship_and_Inequality,
                                        Educational_Attainment))
 
-  } else if (keep_subscales == TRUE){
+  } else if (keep_subscales){
 
     names(.data)[names(.data) == "Financial_Strength"] <- "ADI3_FINS"
     names(.data)[names(.data) == "Economic_Hardship_and_Inequality"] <- "ADI3_ECON"
     names(.data)[names(.data) == "Educational_Attainment"] <- "ADI3_EDU"
 
-    if (return_percentiles == TRUE){
+    if (return_percentiles){
       .data$ADI3_FINS <- dep_percent_rank(.data$ADI3_FINS)
       .data$ADI3_FINS <- .data$ADI3_FINS*100
 

--- a/R/dep_process_ndi.R
+++ b/R/dep_process_ndi.R
@@ -54,16 +54,16 @@ dep_process_ndi_m <- function(.data, geography, year, survey, keep_components,
   names(ndi_m_score)[names(ndi_m_score) == "NDI"] <- "NDI_M"
 
   ### optionally convert to percentiles
-  if (return_percentiles == TRUE){
+  if (return_percentiles){
     ndi_m_score$NDI_M <- dep_percent_rank(ndi_m_score$NDI_M)*100
   }
 
   ## optionally add components back into data
-  if (keep_components == FALSE){
+  if (!keep_components){
 
     out <- ndi_m_score
 
-  } else if (keep_components == TRUE){
+  } else if (keep_components){
 
     ### rename moe components
     names(.data)[names(.data) == "DP04_0002M"] <- "M_HH"
@@ -194,7 +194,7 @@ dep_process_ndi_pw <- function(.data, geography, year, survey, keep_components,
   names(ndi_pw_score)[names(ndi_pw_score) == "NDI"] <- "NDI_PW"
 
   ### optionally convert to percentiles
-  if (return_percentiles == TRUE){
+  if (return_percentiles){
     ndi_tot <- subset(.data, select = c(GEOID, E_TOTPOP))
     ndi_pw_score <- merge(x = ndi_pw_score, y = ndi_tot, by = "GEOID", all.x = TRUE)
 
@@ -204,11 +204,11 @@ dep_process_ndi_pw <- function(.data, geography, year, survey, keep_components,
   }
 
   ## optionally add components back into data
-  if (keep_components == FALSE){
+  if (!keep_components){
 
     out <- ndi_pw_score
 
-  } else if (keep_components == TRUE){
+  } else if (keep_components){
 
     ### rename moe components
     names(.data)[names(.data) == "S0101_C01_001M"] <- "M_TOTPOP"

--- a/R/dep_process_svi.R
+++ b/R/dep_process_svi.R
@@ -5,9 +5,9 @@ dep_process_svi <- function(.data, style, geography, year, survey,
                             multi_svi, debug){
 
   ## subscale creation
-  if ("warnings" %in% debug == TRUE){
+  if ("warnings" %in% debug){
 
-    if (keep_components == TRUE){
+    if (keep_components){
       pri <- dep_process_svi_pri(.data, style = style, geography = geography,
                                  year = year, survey = survey)
     }
@@ -21,8 +21,8 @@ dep_process_svi <- function(.data, style, geography, year, survey,
     theme4 <- dep_process_svi_htt(.data, style = style, geography = geography, year = year,
                                   survey = survey, keep_components = keep_components)
 
-  } else if ("warnings" %in% debug == FALSE){
-    if (keep_components == TRUE){
+  } else if (!("warnings" %in% debug)){
+    if (keep_components){
       pri <- suppressWarnings(dep_process_svi_pri(.data, style = style, geography = geography, year = year,
                                                   survey = survey))
     }
@@ -38,12 +38,12 @@ dep_process_svi <- function(.data, style, geography, year, survey,
   }
 
   ## combine subscales
-  if (keep_components == TRUE){
+  if (keep_components){
 
     out <- merge(x = pri, y = theme1, by = "GEOID", all.x = TRUE)
     out <- merge(x = out, y = theme2, by = "GEOID", all.x = TRUE)
 
-  } else if (keep_components == FALSE){
+  } else if (!keep_components){
 
     out <- merge(x = theme1, y = theme2, by = "GEOID", all.x = TRUE)
 
@@ -58,24 +58,24 @@ dep_process_svi <- function(.data, style, geography, year, survey,
   ## calculate svi percentile
   out$SVI <- dep_percent_rank(out$SPL_THEMES)
 
-  if (return_percentiles == TRUE){
+  if (return_percentiles){
     out$SVI <- out$SVI*100
   }
 
   ## format output
   final_vars <- c("GEOID", "SVI", "SVI_SES", "SVI_HCD", "SVI_MSL", "SVI_HTT")
 
-  if (keep_components == FALSE){
+  if (!keep_components){
 
-    if (keep_subscales == FALSE){
+    if (!keep_subscales){
 
       out <- subset(out, select = c("GEOID", "SVI"))
 
-    } else if (keep_subscales == TRUE){
+    } else if (keep_subscales){
 
       out <- subset(out, select = final_vars)
 
-      if (return_percentiles == TRUE){
+      if (return_percentiles){
 
         out$SVI_SES <- out$SVI_SES*100
         out$SVI_HCD <- out$SVI_HCD*100
@@ -85,10 +85,10 @@ dep_process_svi <- function(.data, style, geography, year, survey,
 
     }
 
-  } else if (keep_components == TRUE){
+  } else if (keep_components){
 
     ## store other variable names in vector
-    other_vars <- names(out)[names(out) %in% final_vars == FALSE]
+    other_vars <- names(out)[!(names(out) %in% final_vars)]
 
     ## combine with final variable vector
     final_vars <- c(final_vars, other_vars)
@@ -99,7 +99,7 @@ dep_process_svi <- function(.data, style, geography, year, survey,
   }
 
   ## create unique variable names
-  if (multi_svi == TRUE){
+  if (multi_svi){
 
     ## get year of style to create postfix
     if (style != "svi20s"){
@@ -111,20 +111,20 @@ dep_process_svi <- function(.data, style, geography, year, survey,
     ## update columns that need to remain unique with postfix
     names(out)[names(out) == "SVI"] <- paste0("SVI", post)
 
-    if (keep_subscales == TRUE){
+    if (keep_subscales){
       names(out)[names(out) == "SVI_SES"] <- paste0("SVI_SES", post)
       names(out)[names(out) == "SVI_HTT"] <- paste0("SVI_HTT", post)
 
-      if (style %in% c("svi20", "svi20s") == TRUE){
+      if (style %in% c("svi20", "svi20s")){
         names(out)[names(out) == "SVI_HCD"] <- paste0("SVI_HOU", post)
         names(out)[names(out) == "SVI_MSL"] <- paste0("SVI_REM", post)
-      } else if (style %in% c("svi10", "svi14") == TRUE){
+      } else if (style %in% c("svi10", "svi14")){
         names(out)[names(out) == "SVI_HCD"] <- paste0("SVI_HCD", post)
         names(out)[names(out) == "SVI_MSL"] <- paste0("SVI_MSL", post)
       }
     }
 
-    if (keep_components == TRUE){
+    if (keep_components){
       names(out)[names(out) == "SP_THEME1"] <- paste0("SP_THEME1", post)
       names(out)[names(out) == "SP_THEME2"] <- paste0("SP_THEME2", post)
       names(out)[names(out) == "SP_THEME3"] <- paste0("SP_THEME3", post)
@@ -132,8 +132,8 @@ dep_process_svi <- function(.data, style, geography, year, survey,
       names(out)[names(out) == "SP_THEMES"] <- paste0("SP_THEMES", post)
     }
 
-  } else if (multi_svi == FALSE){
-    if (style %in% c("svi20", "svi20s") == TRUE & keep_subscales == TRUE){
+  } else if (!multi_svi){
+    if (style %in% c("svi20", "svi20s") & keep_subscales){
       names(out)[names(out) == "SVI_HCD"] <- "SVI_HOU"
       names(out)[names(out) == "SVI_MSL"] <- "SVI_REM"
     }
@@ -198,7 +198,7 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
   names(out)[names(out) == "DP03_0005E"] <- "E_UNEMP"
   names(out)[names(out) == "DP03_0005M"] <- "M_UNEMP"
 
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
 
     names(out)[names(out) == "B17001_001E"] <- "D_POV"
     names(out)[names(out) == "B17001_001M"] <- "DM_POV"
@@ -207,7 +207,7 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
     names(out)[names(out) == "B19301_001E"] <- "E_PCI"
     names(out)[names(out) == "B19301_001M"] <- "M_PCI"
 
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
 
     names(out)[names(out) == "S1701_C01_001E"] <- "D_POV150"
     names(out)[names(out) == "S1701_C01_001M"] <- "DM_POV150"
@@ -226,7 +226,7 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
         names(out)[names(out) == "S2701_C02_001E"] <- "E_UNINSUR"
         names(out)[names(out) == "S2701_C02_001M"] <- "M_UNINSUR"
 
-      } else if (year %in% c(2013, 2014) == TRUE){
+      } else if (year %in% c(2013, 2014)){
 
         names(out)[names(out) == "S2701_C04_062E"] <- "E_UNINSUR"
         names(out)[names(out) == "S2701_C04_062M"] <- "M_UNINSUR"
@@ -270,7 +270,7 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
 
   }
 
-  if (style %in% c("svi20", "svi20s") == TRUE){
+  if (style %in% c("svi20", "svi20s")){
 
     if (year < 2015){
       out$E_HBURD <- out$S2503_C01_032E+out$S2503_C01_036E+out$S2503_C01_040E+out$S2503_C01_044E
@@ -289,12 +289,12 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
   out$EP_UNEMP <- dep_safe_pct(out$E_UNEMP, out$D_UNEMP)
   out$MP_UNEMP <- dep_derived_moe(out$M_UNEMP, out$EP_UNEMP, out$DM_UNEMP, out$DM_UNEMP)
 
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
 
     out$EP_POV <- dep_safe_pct(out$E_POV, out$D_POV)
     out$MP_POV <- dep_derived_moe(out$M_POV, out$EP_POV, out$DM_POV, out$DM_POV)
 
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
 
     out$EP_POV150 <- dep_safe_pct(out$E_POV150, out$D_POV150)
     out$MP_POV150 <- dep_derived_moe(out$M_POV150, out$EP_POV150, out$DM_POV150, out$DM_POV150)
@@ -316,12 +316,12 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
   out$EPL_NOHSDP <- dep_percent_rank(out$EP_NOHSDP)
   out$EPL_UNEMP <- dep_percent_rank(out$EP_UNEMP)
 
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
 
     out$EPL_POV <- dep_percent_rank(out$EP_POV)
     out$EPL_PCI <- 1-dep_percent_rank(out$E_PCI)
 
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
 
     out$EPL_POV150 <- dep_percent_rank(out$EP_POV150)
     out$EPL_UNINSUR <- 1-dep_percent_rank(out$EP_UNINSUR)
@@ -330,9 +330,9 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
   }
 
   ## calculate theme
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
     out$SPL_THEME1 <- out$EPL_POV + out$EPL_UNEMP + out$EPL_PCI + out$EPL_NOHSDP
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
     out$SPL_THEME1 <- out$EPL_POV150 + out$EPL_UNEMP + out$EPL_NOHSDP + out$EPL_UNINSUR + out$EPL_HBURD
   }
 
@@ -340,16 +340,16 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
   out$SVI_SES <- dep_percent_rank(out$SPL_THEME1)
 
   ## update output order
-  if (keep_components == TRUE){
+  if (keep_components){
 
-    if (style %in% c("svi10", "svi14") == TRUE){
+    if (style %in% c("svi10", "svi14")){
       out <- subset(out, select = c(GEOID,
                                     D_POV, DM_POV, E_POV, M_POV, EP_POV, MP_POV, EPL_POV,
                                     D_UNEMP, DM_UNEMP, E_UNEMP, M_UNEMP, EP_UNEMP, MP_UNEMP, EPL_UNEMP,
                                     E_PCI, M_PCI, EPL_PCI,
                                     D_NOHSDP, DM_NOHSDP, E_NOHSDP, M_NOHSDP, EP_NOHSDP, MP_NOHSDP, EPL_NOHSDP,
                                     SPL_THEME1, SVI_SES))
-    } else if (style %in% c("svi20", "svi20s") == TRUE){
+    } else if (style %in% c("svi20", "svi20s")){
 
       if (year < 2017){
         out <- subset(out, select = c(GEOID,
@@ -371,7 +371,7 @@ dep_process_svi_ses <- function(.data, style, geography, year, survey, keep_comp
 
     }
 
-  } else if (keep_components == FALSE){
+  } else if (!keep_components){
 
     out <- subset(out, select = c(GEOID, SPL_THEME1, SVI_SES))
 
@@ -407,18 +407,18 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
     names(out)[names(out) == "S0101_C01_030M"] <- "M_AGE65"
   }
 
-  if (style %in% c("svi14", "svi20", "svi20s") == TRUE){
+  if (style %in% c("svi14", "svi20", "svi20s")){
     names(out)[names(out) == "S2701_C01_001E"] <- "D_DISABL"
     names(out)[names(out) == "S2701_C01_001M"] <- "DM_DISABL"
   }
 
-  if (style %in% c("svi20", "svi20s") == TRUE){
+  if (style %in% c("svi20", "svi20s")){
     names(out)[names(out) == "B16004_001E"] <- "D_LIMENG"
     names(out)[names(out) == "B16004_001M"] <- "DM_LIMENG"
   }
 
   ## calculate components
-  if (style %in% c("svi10", "svi14", "svi20") == TRUE){
+  if (style %in% c("svi10", "svi14", "svi20")){
     out$E_SNGPNT <- out$B25115_009E+out$B25115_012E+out$B25115_022E+out$B25115_025E
     out$M_SNGPNT <- sqrt(out$B25115_009M^2+out$B25115_012M^2+out$B25115_022M^2+out$B25115_025M^2)
   } else if (style == "svi20s"){
@@ -460,7 +460,7 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
 
   }
 
-  if (style %in% c("svi14", "svi20", "svi20s") == TRUE){
+  if (style %in% c("svi14", "svi20", "svi20s")){
 
     ### create variable list
     varlist <- dep_expand_varlist(geography = geography, index = paste0(style, ", dis"),
@@ -480,7 +480,7 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
 
   }
 
-  if (style %in% c("svi20", "svi20s") == TRUE){
+  if (style %in% c("svi20", "svi20s")){
 
     ### create variable list
     varlist <- dep_expand_varlist(geography = geography, index = paste0(style, ", eng"),
@@ -510,12 +510,12 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
   out$EP_SNGPNT <- dep_safe_pct(out$E_SNGPNT, out$D_SNGPNT)
   out$MP_SNGPNT <- dep_derived_moe(out$M_SNGPNT, out$EP_SNGPNT, out$DM_SNGPNT, out$DM_SNGPNT)
 
-  if (style %in% c("svi14", "svi20", "svi20s") == TRUE){
+  if (style %in% c("svi14", "svi20", "svi20s")){
     out$EP_DISABL <- dep_safe_pct(out$E_DISABL, out$D_DISABL)
     out$MP_DISABL <- dep_derived_moe(out$M_DISABL, out$EP_DISABL, out$DM_DISABL, out$DM_DISABL)
   }
 
-  if (style %in% c("svi20", "svi20s") == TRUE){
+  if (style %in% c("svi20", "svi20s")){
     out$EP_LIMENG <- dep_safe_pct(out$E_LIMENG, out$D_LIMENG)
     out$MP_LIMENG <- dep_derived_moe(out$M_LIMENG, out$EP_LIMENG, out$DM_LIMENG, out$DM_LIMENG)
   }
@@ -525,11 +525,11 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
   out$EPL_AGE65 <- dep_percent_rank(out$EP_AGE65)
   out$EPL_SNGPNT <- dep_percent_rank(out$EP_SNGPNT)
 
-  if (style %in% c("svi14", "svi20", "svi20s") == TRUE){
+  if (style %in% c("svi14", "svi20", "svi20s")){
     out$EPL_DISABL <- dep_percent_rank(out$EP_DISABL)
   }
 
-  if (style %in% c("svi20", "svi20s") == TRUE){
+  if (style %in% c("svi20", "svi20s")){
     out$EPL_LIMENG <- dep_percent_rank(out$EP_LIMENG)
   }
 
@@ -538,7 +538,7 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
     out$SPL_THEME2 <- out$EPL_AGE17 + out$EPL_AGE65 + out$EPL_SNGPNT
   } else if (style == "svi14"){
     out$SPL_THEME2 <- out$EPL_AGE17 + out$EPL_AGE65 + out$EPL_DISABL + out$EPL_SNGPNT
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
     out$SPL_THEME2 <- out$EPL_AGE17 + out$EPL_AGE65 + out$EPL_DISABL + out$EPL_SNGPNT + out$EPL_LIMENG
   }
 
@@ -546,7 +546,7 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
   out$SVI_HCD <- dep_percent_rank(out$SPL_THEME2)
 
   ## update output order
-  if (keep_components == TRUE){
+  if (keep_components){
 
     if (style == "svi10"){
 
@@ -563,7 +563,7 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
                                         E_SNGPNT, M_SNGPNT, EP_SNGPNT, MP_SNGPNT, EPL_SNGPNT,
                                         SPL_THEME2, SVI_HCD))
 
-    } else if (style %in% c("svi20", "svi20s") == TRUE){
+    } else if (style %in% c("svi20", "svi20s")){
 
       out <- subset(out, select = c(GEOID, E_AGE17, M_AGE17, EP_AGE17, MP_AGE17, EPL_AGE17,
                                         E_AGE65, M_AGE65, EP_AGE65, MP_AGE65, EPL_AGE65,
@@ -574,7 +574,7 @@ dep_process_svi_hhd <- function(.data, style, geography, year, survey, keep_comp
 
     }
 
-  } else if (keep_components == FALSE){
+  } else if (!keep_components){
     out <- subset(out, select = c(GEOID, SPL_THEME2, SVI_HCD))
   }
 
@@ -598,7 +598,7 @@ dep_process_svi_msl <- function(.data, style, geography, year, survey, keep_comp
   names(out)[names(out) == "S0101_C01_001E"] <- "D_MINRTY"
   names(out)[names(out) == "S0101_C01_001M"] <- "DM_MINRTY"
 
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
     names(out)[names(out) == "B16004_001E"] <- "D_LIMENG"
     names(out)[names(out) == "B16004_001M"] <- "DM_LIMENG"
   }
@@ -607,7 +607,7 @@ dep_process_svi_msl <- function(.data, style, geography, year, survey, keep_comp
   out$E_MINRTY <- out$D_MINRTY-out$B01001H_001E
   out$M_MINRTY <- sqrt(out$DM_MINRTY^2+out$B01001H_001M^2)
 
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
 
     ### create variable list
     varlist <- dep_expand_varlist(geography = geography, index = paste0(style, ", eng"),
@@ -639,26 +639,26 @@ dep_process_svi_msl <- function(.data, style, geography, year, survey, keep_comp
   ## calculate percentiles
   out$EPL_MINRTY <- dep_percent_rank(out$EP_MINRTY)
 
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
     out$EPL_LIMENG <- dep_percent_rank(out$EP_LIMENG)
   }
 
   ### calculate theme
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
     out$SPL_THEME3 <- out$EPL_MINRTY + out$EPL_LIMENG
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
     out$SPL_THEME3 <- out$EPL_MINRTY
   }
 
   ## calculate theme percentile
-  if (style %in% c("svi10", "svi14") == TRUE){
+  if (style %in% c("svi10", "svi14")){
     out$SVI_MSL <- dep_percent_rank(out$SPL_THEME3)
-  } else if (style %in% c("svi20", "svi20s") == TRUE){
+  } else if (style %in% c("svi20", "svi20s")){
     out$SVI_MSL <- out$SPL_THEME3
   }
 
   ### update output order
-  if (keep_components == TRUE){
+  if (keep_components){
 
     if (style %in% c("svi10", "svi14")){
 
@@ -666,14 +666,14 @@ dep_process_svi_msl <- function(.data, style, geography, year, survey, keep_comp
                                     D_LIMENG, DM_LIMENG, E_LIMENG, M_LIMENG, EP_LIMENG, MP_LIMENG, EPL_LIMENG,
                                     SPL_THEME3, SVI_MSL))
 
-    } else if (style %in% c("svi20", "svi20s") == TRUE){
+    } else if (style %in% c("svi20", "svi20s")){
 
       out <- subset(out, select = c(GEOID, E_MINRTY, M_MINRTY, EP_MINRTY, MP_MINRTY, EPL_MINRTY,
                                     SPL_THEME3, SVI_MSL))
 
     }
 
-  } else if (keep_components == FALSE){
+  } else if (!keep_components){
 
     out <- subset(out, select = c(GEOID, SPL_THEME3, SVI_MSL))
 
@@ -767,7 +767,7 @@ dep_process_svi_htt <- function(.data, style, geography, year, survey, keep_comp
   .data$SVI_HTT <- dep_percent_rank(.data$SPL_THEME4)
 
   ## update output order
-  if (keep_components == TRUE){
+  if (keep_components){
 
     .data <- subset(.data, select = c(GEOID, E_MUNIT, M_MUNIT, EP_MUNIT, MP_MUNIT, EPL_MUNIT,
                                       E_MOBILE, M_MOBILE, EP_MOBILE, MP_MOBILE, EPL_MOBILE,
@@ -776,7 +776,7 @@ dep_process_svi_htt <- function(.data, style, geography, year, survey, keep_comp
                                       E_GROUPQ, M_GROUPQ, EP_GROUPQ, MP_GROUPQ, EPL_GROUPQ,
                                       SPL_THEME4, SVI_HTT))
 
-  } else if (keep_components == FALSE){
+  } else if (!keep_components){
 
     .data <- subset(.data, select = c(GEOID, SPL_THEME4, SVI_HTT))
 

--- a/R/dep_rank.R
+++ b/R/dep_rank.R
@@ -34,7 +34,7 @@ dep_percentiles <- function(.data, source_var, new_var){
 
   source_varQN <- as.character(substitute(source_var))
 
-  if (source_varQN %in% names(.data) == FALSE){
+  if (!(source_varQN %in% names(.data))){
     cli::cli_abort(c(
       "The given {.arg source_var} column is not found in your data object.",
       "i" = "Column {.val {source_varQN}} does not exist."
@@ -50,7 +50,7 @@ dep_percentiles <- function(.data, source_var, new_var){
   } else if (!missing(new_var)){
     new_varQN <- as.character(substitute(new_var))
 
-    if (new_varQN %in% names(.data) == TRUE){
+    if (new_varQN %in% names(.data)){
       cli::cli_warn("The given {.arg new_var} column exists in your data and will be overwritten.")
     }
   }

--- a/R/dep_sample_data.R
+++ b/R/dep_sample_data.R
@@ -23,14 +23,14 @@
 dep_sample_data <- function(index){
 
   # check inputs
-  if (missing(index) == TRUE){
+  if (missing(index)){
     cli::cli_abort(c(
       "A {.arg index} value must be provided.",
       "i" = "Choose one of: {.val adi}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
     ))
   }
 
-  if (all(index %in% c("adi", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE){
+  if (!all(index %in% c("adi", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s"))){
     cli::cli_abort(c(
       "Invalid {.arg index} provided: {.val {index}}.",
       "i" = "Choose one of: {.val adi}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."

--- a/R/dep_utils.R
+++ b/R/dep_utils.R
@@ -1,7 +1,7 @@
 pivot_demos <- function(.data, vars){
 
   out <- tidyr::pivot_longer(.data, cols = dplyr::all_of(vars), names_to = "variable", values_to = "values")
-  out$variable <- ifelse(grepl("E", out$variable, fixed = TRUE) == TRUE, "estimate", "moe")
+  out$variable <- ifelse(grepl("E", out$variable, fixed = TRUE), "estimate", "moe")
 
   out <- suppressWarnings(tidyr::pivot_wider(out, id_cols = GEOID, names_from = variable, values_from = values))
   out <- tidyr::unchop(out, cols = c(GEOID, estimate, moe))
@@ -54,7 +54,7 @@ dep_validate_inputs <- function(geography, index, year, survey,
     ))
   }
 
-  if (geography %in% c("county", "zcta3", "zcta5", "tract") == FALSE) {
+  if (!(geography %in% c("county", "zcta3", "zcta5", "tract"))) {
     cli::cli_abort(c(
       "Invalid {.arg geography} provided: {.val {geography}}.",
       "i" = "Choose one of: {.val county}, {.val zcta3}, {.val zcta5}, or {.val tract}."
@@ -69,7 +69,7 @@ dep_validate_inputs <- function(geography, index, year, survey,
     ))
   }
 
-  if (all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s")) == FALSE) {
+  if (!all(index %in% c("adi", "gini", "ndi_m", "ndi_pw", "svi10", "svi14", "svi20", "svi20s"))) {
     cli::cli_abort(c(
       "Invalid {.arg index} provided: {.val {index}}.",
       "i" = "Choose one of: {.val adi}, {.val gini}, {.val ndi_m}, {.val ndi_pw}, {.val svi10}, {.val svi14}, {.val svi20}, or {.val svi20s}."
@@ -84,21 +84,21 @@ dep_validate_inputs <- function(geography, index, year, survey,
     ))
   }
 
-  if (is.numeric(year) == FALSE | (min(year) < 2010 | max(year) > 2022)) {
+  if (!is.numeric(year) | (min(year) < 2010 | max(year) > 2022)) {
     cli::cli_abort(c(
       "The {.arg year} value provided is invalid.",
       "i" = "Please provide a numeric value between 2010 and 2022."
     ))
   }
 
-  if (any(index %in% c("svi14", "svi20")) == TRUE & min(year) < 2012) {
+  if (any(index %in% c("svi14", "svi20")) & min(year) < 2012) {
     cli::cli_abort(c(
       "The {.arg year} value is not valid for 2014 or 2020 SVI specifications.",
       "i" = "Each of those can be calculated from 2012 onward. Use {.val svi10} for 2010 or 2011."
     ))
   }
 
-  if (any(index == "svi20s") == TRUE & min(year) < 2019) {
+  if (any(index == "svi20s") & min(year) < 2019) {
     cli::cli_abort(c(
       "The {.arg year} value is not valid for the 2020 SVI specification with the alternate single parent measure.",
       "i" = "This can only be calculated for 2019 onward."
@@ -106,7 +106,7 @@ dep_validate_inputs <- function(geography, index, year, survey,
   }
 
   # survey
-  if (survey %in% c("acs1", "acs3", "acs5") == FALSE) {
+  if (!(survey %in% c("acs1", "acs3", "acs5"))) {
     cli::cli_abort(c(
       "The {.arg survey} value provided is not valid: {.val {survey}}.",
       "i" = "Choose one of: {.val acs1}, {.val acs3}, or {.val acs5}."
@@ -121,27 +121,27 @@ dep_validate_inputs <- function(geography, index, year, survey,
   }
 
   # logical scalars
-  if (is.logical(return_percentiles) == FALSE) {
+  if (!is.logical(return_percentiles)) {
     cli::cli_abort("Please provide a logical scalar for {.arg return_percentiles}.")
   }
 
-  if (is.logical(keep_subscales) == FALSE) {
+  if (!is.logical(keep_subscales)) {
     cli::cli_abort("Please provide a logical scalar for {.arg keep_subscales}.")
   }
 
-  if (is.logical(keep_components) == FALSE) {
+  if (!is.logical(keep_components)) {
     cli::cli_abort("Please provide a logical scalar for {.arg keep_components}.")
   }
 
   # output
-  if (output %in% valid_output == FALSE) {
+  if (!(output %in% valid_output)) {
     cli::cli_abort(c(
       "The {.arg output} value provided is not valid: {.val {output}}.",
       "i" = "Choose one of: {.val {valid_output}}."
     ))
   }
 
-  if (output == "tidy" & keep_components == TRUE) {
+  if (output == "tidy" & keep_components) {
     cli::cli_abort(c(
       "The {.arg output} requested is invalid.",
       "i" = "Tidy output is only available if {.arg keep_components} is {.code FALSE}."


### PR DESCRIPTION
## Summary

Replaces all `== TRUE` and `== FALSE` comparisons with idiomatic R equivalents across the entire `R/` source directory. This is a mechanical, behavior-preserving refactor that improves code conciseness and resilience to NA edge cases.

## Implementation

- 12 files updated, 205 symmetric line changes
- Transformation rules applied:
  - `if (x == TRUE)` → `if (x)`
  - `if (x == FALSE)` → `if (!x)`
  - `if (expr %in% set == TRUE)` → `if (expr %in% set)`
  - `if (expr %in% set == FALSE)` → `if (!(expr %in% set))`
- Column-value filters in `subset()` (e.g., `out$set5 == TRUE`) preserved — these are legitimate row filters, not the anti-pattern
- Commented-out lines left untouched

## Testing

- All 560 existing tests pass (0 failures, 1 pre-existing skip)
- No new tests needed — behavior is unchanged

## Closes

- Closes #65

## Notes

- Part of [Epic F] Code Quality & Test Coverage (#52)
- Identified in deep code analysis (#50, Finding 7)
- Operator precedence verified for all `%in%` negations (wrapped with parentheses)