### PR TITLE
fix: compare territory FIPS codes instead of abbreviations in dep_get_index

### DIFF
--- a/R/dep_get_index.R
+++ b/R/dep_get_index.R
@@ -178,7 +178,7 @@ dep_get_index <- function(geography, index, year, survey = "acs5",
     state <- unlist(sapply(state, validate_state, USE.NAMES=FALSE))
   }
 
-  if (any(state %in% c("AS", "GU", "MP", "PR", "VI"))){
+  if (any(state %in% c("60", "66", "69", "72", "78"))){
     cli::cli_abort(c(
       "Territories cannot be specified using the {.arg state} argument.",
       "i" = "Use the {.arg puerto_rico} argument for Puerto Rico.",

--- a/tests/testthat/test_dep_get_index.R
+++ b/tests/testthat/test_dep_get_index.R
@@ -105,11 +105,49 @@ test_that("non-logical keep_components triggers error", {
 })
 
 test_that("territory in state argument triggers error", {
-  # Note: validate_state converts abbreviations to FIPS codes before the
+  # Abbreviation input (converted to FIPS by validate_state before the check)
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "PR"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "AS"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "GU"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "MP"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "VI"),
+    "Territories cannot be specified"
+  )
 
-  # territory check runs, so we pass the FIPS code directly to trigger the
-  # correct validation path. This is a known issue in the package.
-  skip("Territory validation compares FIPS against abbreviations - known bug")
+  # Direct FIPS input
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "72"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "60"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "66"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "69"),
+    "Territories cannot be specified"
+  )
+  expect_error(
+    dep_get_index(geography = "county", index = "ndi_m", year = 2020, survey = "acs5", state = "78"),
+    "Territories cannot be specified"
+  )
 })
 
 test_that("state and county both specified triggers error", {


### PR DESCRIPTION
## Summary

Fixes the territory validation bug in `dep_get_index()` where the guard clause compared FIPS codes (output of `validate_state()`) against abbreviation strings, causing the check to never match.

## Implementation

- Changed the territory comparison on line 181 from abbreviation strings (`"AS", "GU", "MP", "PR", "VI"`) to FIPS codes (`"60", "66", "69", "72", "78"`)
- This aligns with the existing `dep_territory_fips()` helper convention in `dep_get_data.R`

## Testing

- Un-skipped the previously-disabled territory validation test
- Expanded test coverage to all 5 territories × 2 input formats (abbreviation + FIPS) = 10 assertions
- All 31 tests in `test_dep_get_index.R` pass

## Closes

Closes #72

## Notes

Single-line logic fix; no API or behavioral changes beyond correcting the broken validation path.
