### PR TITLE
fix: pass explicit dest_dir to pkgdown to avoid docs/ conflict

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -29,7 +29,7 @@ jobs:
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "_site")
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀


### PR DESCRIPTION
## Summary

Passes `dest_dir = "_site"` explicitly to `pkgdown::build_site_github_pages()` so it no longer inspects the governance `docs/` directory and errors with `check_dest_is_pkgdown()`.

## Motivation

Closes #74 — the pkgdown CI job fails because `docs/` contains non-pkgdown files (architecture, glossary, roadmap, etc.).

## Changes

- `.github/workflows/pkgdown.yml`: added `dest_dir = "_site"` argument (consistent with `destination: _site` already in `_pkgdown.yml`)

## Testing

- YAML syntax verified locally
- The `destination: _site` in `_pkgdown.yml` and the explicit `dest_dir` in the workflow are now consistent — pkgdown will output to `_site/` and the deploy step already reads from that folder

## Notes

One-line fix. No behavioral change to the built site — only prevents the pre-build directory check from erroring on `docs/`.