### PR TITLE
fix: add dep_set_api_key to _pkgdown.yml reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,6 +20,11 @@ reference:
     - dep_percentiles
     - dep_map_breaks
 
+  - title: "Configuration"
+    desc: "Set Up API Keys and Credentials"
+    contents:
+    - dep_set_api_key
+
   - title: "Sample Data"
     desc: "Data Used for Examples"
     contents:


### PR DESCRIPTION
## Summary

Adds `dep_set_api_key` to a new "Configuration" section in `_pkgdown.yml` so pkgdown's reference index includes all exported topics.

## Motivation

Closes #76 — pkgdown fails with `1 topic missing from index: "dep_set_api_key"`.

## Changes

- `_pkgdown.yml`: added "Configuration" reference section containing `dep_set_api_key`

## Testing

- YAML structure verified locally
- All exported functions now accounted for in the reference index

## Notes

Follow-up to #74/#75 (docs/ directory conflict fix). This resolves the next pkgdown CI blocker.