### PR TITLE
fix: switch GitHub Pages deploy to first-party actions

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -5,12 +5,18 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
-  pkgdown:
+  build:
     runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -32,10 +38,18 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "_site")
         shell: Rscript {0}
 
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          clean: false
-          branch: gh-pages
-          folder: _site
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Replace `JamesIves/github-pages-deploy-action@v4` with GitHub's official `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` to fix the 403 permission error when deploying to GitHub Pages.

## Changes

- Added `permissions:` block (`contents: read`, `pages: write`, `id-token: write`)
- Split workflow into `build` + `deploy` jobs (required by deploy-pages)
- Replaced third-party deploy action with first-party `upload-pages-artifact@v3` + `deploy-pages@v4`
- Added `environment: github-pages` with URL output
- Simplified concurrency group to match Pages convention

## Post-merge manual step

> **Required:** Settings → Pages → Source → select **"GitHub Actions"** (not "Deploy from a branch")

Once confirmed working, the `gh-pages` branch can be deleted.

## Closes

Closes #78